### PR TITLE
Parties/PartyMembers API 커스텀 에러코드 및 Swagger 문서 일관성 개선

### DIFF
--- a/src/parties/controllers/parties.controller.ts
+++ b/src/parties/controllers/parties.controller.ts
@@ -66,7 +66,22 @@ export class PartiesController {
 			},
 		},
 	})
-	@ApiUnauthorizedResponse({ description: '인증되지 않은 사용자입니다.' })
+	@ApiUnauthorizedResponse({
+		description: '인증되지 않은 사용자입니다.',
+		content: {
+			'application/json': {
+				example: {
+					success: false,
+					statusCode: 401,
+					errorCode: 'a-002',
+					message: '인증되지 않은 사용자입니다.',
+					detail: '유효한 인증 토큰이 제공되지 않았습니다.',
+					timestamp: '2025-07-03T10:00:00.000Z',
+					path: '/parties',
+				},
+			},
+		},
+	})
 	@ApiNotFoundResponse({
 		description: '존재하지 않는 리소스입니다. (e.g. 게임, 사용자, 게임 프로필)',
 		content: {
@@ -108,7 +123,22 @@ export class PartiesController {
 	@Get(':id')
 	@ApiOperation({ summary: '특정 파티 조회' })
 	@ApiOkResponse({ description: '파티 + 멤버 정보를 반환합니다.', type: PartyWithMembersDto })
-	@ApiUnauthorizedResponse({ description: '인증되지 않은 사용자입니다.' })
+	@ApiUnauthorizedResponse({
+		description: '인증되지 않은 사용자입니다.',
+		content: {
+			'application/json': {
+				example: {
+					success: false,
+					statusCode: 401,
+					errorCode: 'a-002',
+					message: '인증되지 않은 사용자입니다.',
+					detail: '유효한 인증 토큰이 제공되지 않았습니다.',
+					timestamp: '2025-07-03T10:00:00.000Z',
+					path: '/parties/1',
+				},
+			},
+		},
+	})
 	@ApiNotFoundResponse({
 		description: '파티를 찾을 수 없습니다.',
 		content: {
@@ -151,7 +181,22 @@ export class PartiesController {
 			},
 		},
 	})
-	@ApiUnauthorizedResponse({ description: '인증되지 않은 사용자입니다.' })
+	@ApiUnauthorizedResponse({
+		description: '인증되지 않은 사용자입니다.',
+		content: {
+			'application/json': {
+				example: {
+					success: false,
+					statusCode: 401,
+					errorCode: 'a-002',
+					message: '인증되지 않은 사용자입니다.',
+					detail: '유효한 인증 토큰이 제공되지 않았습니다.',
+					timestamp: '2025-07-03T10:00:00.000Z',
+					path: '/parties/1',
+				},
+			},
+		},
+	})
 	@ApiForbiddenResponse({
 		description: '권한이 없습니다.',
 		content: {
@@ -211,10 +256,29 @@ export class PartiesController {
 	@ApiOperation({ summary: '파티 삭제' })
 	@ApiOkResponse({
 		description: '파티가 성공적으로 삭제되었습니다.',
-		schema: { example: { message: '파티가 성공적으로 삭제되었습니다.' } },
+		content: {
+			'application/json': {
+				example: { message: '파티가 성공적으로 삭제되었습니다.' },
+			},
+		},
 	})
 	@HttpCode(HttpStatus.OK) // 성공 시 200 OK
-	@ApiUnauthorizedResponse({ description: '인증되지 않은 사용자입니다.' })
+	@ApiUnauthorizedResponse({
+		description: '인증되지 않은 사용자입니다.',
+		content: {
+			'application/json': {
+				example: {
+					success: false,
+					statusCode: 401,
+					errorCode: 'a-002',
+					message: '인증되지 않은 사용자입니다.',
+					detail: '유효한 인증 토큰이 제공되지 않았습니다.',
+					timestamp: '2025-07-03T10:00:00.000Z',
+					path: '/parties/1',
+				},
+			},
+		},
+	})
 	@ApiForbiddenResponse({
 		description: '파티 생성자만 삭제할 수 있습니다.',
 		content: {
@@ -259,33 +323,22 @@ export class PartiesController {
 	@ApiOperation({ summary: '파티 목록 조회' })
 	@ApiOkResponse({
 		description: '파티 목록을 반환합니다.',
-		type: PartyListItemDto,
-		isArray: true,
-		schema: {
-			example: [
-				{
-					id: 1,
-					title: '같이 즐겁게 게임해요',
-					gameId: 1,
-					gameBannerUrl:
-						'https://cdn.cloudflare.steamstatic.com/steam/apps/570/header.jpg',
-					creatorId: 1,
-					purposeTag: '레이드',
-					maxParticipants: 8,
-					description: '파티 설명',
-					isPrivate: false,
-					accessCode: null,
-					isCompleted: false,
-					createdAt: '2025-06-10T18:00:00',
-					updatedAt: '2025-06-10T18:00:00',
-					leader: {
-						userId: 1,
-						username: 'user1',
-						gameUsername: 'pro_gamer123',
-					},
-					currentMemberCount: 3,
+		type: [PartyListItemDto],
+	})
+	@ApiUnauthorizedResponse({
+		description: '인증되지 않은 사용자입니다.',
+		content: {
+			'application/json': {
+				example: {
+					success: false,
+					statusCode: 401,
+					errorCode: 'a-002',
+					message: '인증되지 않은 사용자입니다.',
+					detail: '유효한 인증 토큰이 제공되지 않았습니다.',
+					timestamp: '2025-07-03T10:00:00.000Z',
+					path: '/parties',
 				},
-			],
+			},
 		},
 	})
 	@ApiQuery({ name: 'gameId', required: false, type: Number, description: '게임 ID' })
@@ -313,7 +366,11 @@ export class PartiesController {
 	@ApiOperation({ summary: '파티 완료 처리' })
 	@ApiOkResponse({
 		description: '파티가 완료 처리되었습니다.',
-		schema: { example: { message: '파티가 완료 처리되었습니다.' } },
+		content: {
+			'application/json': {
+				example: { message: '파티가 완료 처리되었습니다.' },
+			},
+		},
 	})
 	@ApiBadRequestResponse({
 		description: '이미 완료된 파티입니다.',
@@ -331,7 +388,22 @@ export class PartiesController {
 			},
 		},
 	})
-	@ApiUnauthorizedResponse({ description: '인증되지 않은 사용자입니다.' })
+	@ApiUnauthorizedResponse({
+		description: '인증되지 않은 사용자입니다.',
+		content: {
+			'application/json': {
+				example: {
+					success: false,
+					statusCode: 401,
+					errorCode: 'a-002',
+					message: '인증되지 않은 사용자입니다.',
+					detail: '유효한 인증 토큰이 제공되지 않았습니다.',
+					timestamp: '2025-07-03T10:00:00.000Z',
+					path: '/parties/1/complete',
+				},
+			},
+		},
+	})
 	@ApiForbiddenResponse({
 		description: '파티 생성자만 완료 처리할 수 있습니다.',
 		content: {

--- a/src/parties/controllers/parties.controller.ts
+++ b/src/parties/controllers/parties.controller.ts
@@ -9,6 +9,8 @@ import {
 	Patch,
 	Delete,
 	Query,
+	HttpCode,
+	HttpStatus,
 } from '@nestjs/common';
 import { PartiesService } from '../services/parties.service';
 import { CreatePartyDto } from '../dto/create-party.dto';
@@ -30,7 +32,7 @@ import {
 import { PartyWithMembersDto } from '../dto/party-with-members.dto';
 import { GetUser } from '../../auth/decorator/get-user.decorator';
 
-@ApiTags('parties')
+@ApiTags('Parties')
 @ApiBearerAuth()
 @UseGuards(JwtAuthGuard)
 @Controller('parties')
@@ -44,42 +46,55 @@ export class PartiesController {
 		type: PartyWithMembersDto,
 	})
 	@ApiBadRequestResponse({
-		description: '잘못된 요청 데이터입니다.',
-		schema: {
-			example: {
-				success: false,
-				statusCode: 400,
-				errorCode: 'g-001',
-				message: '입력 데이터가 유효하지 않습니다.',
-				detail: '비공개 파티는 참여 코드가 필요합니다.',
-				timestamp: '2025-06-30T12:00:00.000Z',
-				path: '/parties',
+		description:
+			'잘못된 요청 데이터입니다. (e.g. 비공개 파티에 참여 코드가 없는 경우, 게임 프로필 정보가 없는 경우)',
+		content: {
+			'application/json': {
+				examples: {
+					'Validation Error': {
+						value: {
+							success: false,
+							statusCode: 400,
+							errorCode: 'g-001',
+							message: '입력 데이터가 유효하지 않습니다.',
+							detail: '비공개 파티는 참여 코드가 필요합니다.',
+							timestamp: '2025-07-03T10:00:00.000Z',
+							path: '/parties',
+						},
+					},
+				},
 			},
 		},
 	})
-	@ApiUnauthorizedResponse({
-		description: '인증이 필요합니다.',
-		schema: {
-			example: {
-				success: false,
-				statusCode: 401,
-				message: 'Unauthorized',
-				timestamp: '2025-06-30T12:00:00.000Z',
-				path: '/parties',
-			},
-		},
-	})
+	@ApiUnauthorizedResponse({ description: '인증되지 않은 사용자입니다.' })
 	@ApiNotFoundResponse({
-		description: '존재하지 않는 게임입니다.',
-		schema: {
-			example: {
-				success: false,
-				statusCode: 404,
-				errorCode: 'gm-001',
-				message: '게임을 찾을 수 없습니다.',
-				detail: '존재하지 않는 게임입니다.',
-				timestamp: '2025-06-30T12:00:00.000Z',
-				path: '/parties',
+		description: '존재하지 않는 리소스입니다. (e.g. 게임, 사용자, 게임 프로필)',
+		content: {
+			'application/json': {
+				examples: {
+					'Game Not Found': {
+						value: {
+							success: false,
+							statusCode: 404,
+							errorCode: 'gm-001',
+							message: '게임을 찾을 수 없습니다.',
+							detail: '존재하지 않는 게임입니다.',
+							timestamp: '2025-07-03T10:00:00.000Z',
+							path: '/parties',
+						},
+					},
+					'User Not Found': {
+						value: {
+							success: false,
+							statusCode: 404,
+							errorCode: 'a-001',
+							message: '사용자를 찾을 수 없습니다.',
+							detail: '존재하지 않는 사용자입니다.',
+							timestamp: '2025-07-03T10:00:00.000Z',
+							path: '/parties',
+						},
+					},
+				},
 			},
 		},
 	})
@@ -93,29 +108,20 @@ export class PartiesController {
 	@Get(':id')
 	@ApiOperation({ summary: '특정 파티 조회' })
 	@ApiOkResponse({ description: '파티 + 멤버 정보를 반환합니다.', type: PartyWithMembersDto })
-	@ApiUnauthorizedResponse({
-		description: '인증이 필요합니다.',
-		schema: {
-			example: {
-				success: false,
-				statusCode: 401,
-				message: 'Unauthorized',
-				timestamp: '2025-06-30T12:00:00.000Z',
-				path: '/parties/1',
-			},
-		},
-	})
+	@ApiUnauthorizedResponse({ description: '인증되지 않은 사용자입니다.' })
 	@ApiNotFoundResponse({
 		description: '파티를 찾을 수 없습니다.',
-		schema: {
-			example: {
-				success: false,
-				statusCode: 404,
-				errorCode: 'p-001',
-				message: '파티를 찾을 수 없습니다.',
-				detail: '존재하지 않는 파티입니다.',
-				timestamp: '2025-06-30T12:00:00.000Z',
-				path: '/parties/1',
+		content: {
+			'application/json': {
+				example: {
+					success: false,
+					statusCode: 404,
+					errorCode: 'p-001',
+					message: '파티를 찾을 수 없습니다.',
+					detail: '존재하지 않는 파티입니다.',
+					timestamp: '2025-07-03T10:00:00.000Z',
+					path: '/parties/999',
+				},
 			},
 		},
 	})
@@ -131,44 +137,65 @@ export class PartiesController {
 	})
 	@ApiBadRequestResponse({
 		description: '잘못된 요청 데이터입니다.',
-		schema: {
-			example: {
-				success: false,
-				statusCode: 400,
-				errorCode: 'g-001',
-				message: '입력 데이터가 유효하지 않습니다.',
-				detail: 'profileId 또는 gameUsername 중 하나만 입력해야 합니다.',
-				timestamp: '2025-07-01T12:00:00.000Z',
-				path: '/parties/1',
+		content: {
+			'application/json': {
+				example: {
+					success: false,
+					statusCode: 400,
+					errorCode: 'g-001',
+					message: '입력 데이터가 유효하지 않습니다.',
+					detail: '비공개 파티는 참여 코드가 필요합니다.',
+					timestamp: '2025-07-03T10:00:00.000Z',
+					path: '/parties/1',
+				},
 			},
 		},
 	})
-	@ApiUnauthorizedResponse({ description: '인증이 필요합니다.' })
+	@ApiUnauthorizedResponse({ description: '인증되지 않은 사용자입니다.' })
 	@ApiForbiddenResponse({
 		description: '권한이 없습니다.',
-		schema: {
-			example: {
-				success: false,
-				statusCode: 403,
-				errorCode: 'g-004',
-				message: '요청을 수행할 권한이 없습니다.',
-				detail: '파티를 수정할 권한이 없습니다.',
-				timestamp: '2025-07-01T12:00:00.000Z',
-				path: '/parties/1',
+		content: {
+			'application/json': {
+				example: {
+					success: false,
+					statusCode: 403,
+					errorCode: 'g-004',
+					message: '요청을 수행할 권한이 없습니다.',
+					detail: '파티를 수정할 권한이 없습니다.',
+					timestamp: '2025-07-03T10:00:00.000Z',
+					path: '/parties/1',
+				},
 			},
 		},
 	})
 	@ApiNotFoundResponse({
 		description: '파티 또는 게임 프로필을 찾을 수 없습니다.',
-		schema: {
-			example: {
-				success: false,
-				statusCode: 404,
-				errorCode: 'p-001',
-				message: '파티를 찾을 수 없습니다.',
-				detail: '존재하지 않는 파티입니다.',
-				timestamp: '2025-07-01T12:00:00.000Z',
-				path: '/parties/1',
+		content: {
+			'application/json': {
+				examples: {
+					'Party Not Found': {
+						value: {
+							success: false,
+							statusCode: 404,
+							errorCode: 'p-001',
+							message: '파티를 찾을 수 없습니다.',
+							detail: '존재하지 않는 파티입니다.',
+							timestamp: '2025-07-03T10:00:00.000Z',
+							path: '/parties/1',
+						},
+					},
+					'Profile Not Found': {
+						value: {
+							success: false,
+							statusCode: 404,
+							errorCode: 'ugp-001',
+							message: '사용자 게임 프로필을 찾을 수 없습니다.',
+							detail: '선택한 게임 프로필이 유효하지 않습니다.',
+							timestamp: '2025-07-03T10:00:00.000Z',
+							path: '/parties/1',
+						},
+					},
+				},
 			},
 		},
 	})
@@ -185,6 +212,40 @@ export class PartiesController {
 	@ApiOkResponse({
 		description: '파티가 성공적으로 삭제되었습니다.',
 		schema: { example: { message: '파티가 성공적으로 삭제되었습니다.' } },
+	})
+	@HttpCode(HttpStatus.OK) // 성공 시 200 OK
+	@ApiUnauthorizedResponse({ description: '인증되지 않은 사용자입니다.' })
+	@ApiForbiddenResponse({
+		description: '파티 생성자만 삭제할 수 있습니다.',
+		content: {
+			'application/json': {
+				example: {
+					success: false,
+					statusCode: 403,
+					errorCode: 'p-010',
+					message: '파티 생성자만 수행할 수 있는 작업입니다.',
+					detail: '파티 생성자 권한이 필요합니다.',
+					timestamp: '2025-07-03T10:00:00.000Z',
+					path: '/parties/1',
+				},
+			},
+		},
+	})
+	@ApiNotFoundResponse({
+		description: '파티를 찾을 수 없습니다.',
+		content: {
+			'application/json': {
+				example: {
+					success: false,
+					statusCode: 404,
+					errorCode: 'p-001',
+					message: '파티를 찾을 수 없습니다.',
+					detail: '존재하지 않는 파티입니다.',
+					timestamp: '2025-07-03T10:00:00.000Z',
+					path: '/parties/1',
+				},
+			},
+		},
 	})
 	async deleteParty(
 		@Param('id', ParseIntPipe) id: number,
@@ -256,55 +317,50 @@ export class PartiesController {
 	})
 	@ApiBadRequestResponse({
 		description: '이미 완료된 파티입니다.',
-		schema: {
-			example: {
-				success: false,
-				statusCode: 400,
-				errorCode: 'p-009',
-				message: '이미 완료된 파티입니다.',
-				detail: '완료된 파티는 더 이상 수정할 수 없습니다.',
-				timestamp: '2025-06-30T12:00:00.000Z',
-				path: '/parties/1/complete',
+		content: {
+			'application/json': {
+				example: {
+					success: false,
+					statusCode: 400,
+					errorCode: 'p-009',
+					message: '이미 완료된 파티입니다.',
+					detail: '완료된 파티의 상태는 변경할 수 없습니다.',
+					timestamp: '2025-07-03T10:00:00.000Z',
+					path: '/parties/1/complete',
+				},
 			},
 		},
 	})
-	@ApiUnauthorizedResponse({
-		description: '인증이 필요합니다.',
-		schema: {
-			example: {
-				success: false,
-				statusCode: 401,
-				message: 'Unauthorized',
-				timestamp: '2025-06-30T12:00:00.000Z',
-				path: '/parties/1/complete',
-			},
-		},
-	})
+	@ApiUnauthorizedResponse({ description: '인증되지 않은 사용자입니다.' })
 	@ApiForbiddenResponse({
 		description: '파티 생성자만 완료 처리할 수 있습니다.',
-		schema: {
-			example: {
-				success: false,
-				statusCode: 403,
-				errorCode: 'p-010',
-				message: '파티 생성자만 수행할 수 있는 작업입니다.',
-				detail: '파티 생성자 권한이 필요합니다.',
-				timestamp: '2025-06-30T12:00:00.000Z',
-				path: '/parties/1/complete',
+		content: {
+			'application/json': {
+				example: {
+					success: false,
+					statusCode: 403,
+					errorCode: 'p-010',
+					message: '파티 생성자만 수행할 수 있는 작업입니다.',
+					detail: '파티 생성자 권한이 필요합니다.',
+					timestamp: '2025-07-03T10:00:00.000Z',
+					path: '/parties/1/complete',
+				},
 			},
 		},
 	})
 	@ApiNotFoundResponse({
 		description: '파티를 찾을 수 없습니다.',
-		schema: {
-			example: {
-				success: false,
-				statusCode: 404,
-				errorCode: 'p-001',
-				message: '파티를 찾을 수 없습니다.',
-				detail: '존재하지 않는 파티입니다.',
-				timestamp: '2025-06-30T12:00:00.000Z',
-				path: '/parties/1/complete',
+		content: {
+			'application/json': {
+				example: {
+					success: false,
+					statusCode: 404,
+					errorCode: 'p-001',
+					message: '파티를 찾을 수 없습니다.',
+					detail: '존재하지 않는 파티입니다.',
+					timestamp: '2025-07-03T10:00:00.000Z',
+					path: '/parties/1/complete',
+				},
 			},
 		},
 	})

--- a/src/parties/controllers/party-members.controller.ts
+++ b/src/parties/controllers/party-members.controller.ts
@@ -124,6 +124,7 @@ export class PartyMembersController {
 
 	@Get()
 	@ApiBearerAuth()
+	@UseGuards(JwtAuthGuard)
 	@ApiOperation({ summary: '파티 멤버 목록 조회' })
 	@ApiOkResponse({ description: '파티 멤버 목록을 반환합니다.' })
 	@ApiUnauthorizedResponse({
@@ -148,6 +149,8 @@ export class PartyMembersController {
 	}
 
 	@Delete('/:userId')
+	@ApiBearerAuth()
+	@UseGuards(JwtAuthGuard)
 	@ApiOperation({ summary: '파티원 강퇴 (파티장만)' })
 	@ApiOkResponse({
 		description: '파티원을 강퇴했습니다.',
@@ -157,23 +160,38 @@ export class PartyMembersController {
 		description: '자기 자신을 강퇴할 수 없습니다.',
 		schema: {
 			example: {
+				success: false,
 				statusCode: 400,
+				errorCode: 'p-008',
 				message: '자기 자신을 강퇴할 수 없습니다.',
-				error: 'Bad Request',
+				detail: '파티장은 자기 자신을 강퇴할 수 없습니다.',
+				timestamp: '2025-06-30T12:00:00.000Z',
+				path: '/parties/1/members/1',
 			},
 		},
 	})
 	@ApiUnauthorizedResponse({
 		description: '인증이 필요합니다.',
-		schema: { example: { statusCode: 401, message: 'Unauthorized' } },
+		schema: {
+			example: {
+				success: false,
+				statusCode: 401,
+				errorCode: 'u-001',
+				message: '인증이 필요합니다.',
+			},
+		},
 	})
 	@ApiForbiddenResponse({
 		description: '파티장만 강퇴할 수 있습니다.',
 		schema: {
 			example: {
+				success: false,
 				statusCode: 403,
-				message: '파티장만 강퇴할 수 있습니다.',
-				error: 'Forbidden',
+				errorCode: 'p-002',
+				message: '파티장만 이 작업을 수행할 수 있습니다.',
+				detail: '오직 파티장만 멤버를 강퇴할 수 있습니다.',
+				timestamp: '2025-06-30T12:00:00.000Z',
+				path: '/parties/1/members/2',
 			},
 		},
 	})
@@ -181,9 +199,13 @@ export class PartyMembersController {
 		description: '파티나 멤버를 찾을 수 없습니다.',
 		schema: {
 			example: {
+				success: false,
 				statusCode: 404,
+				errorCode: 'p-007',
 				message: '해당 멤버를 찾을 수 없습니다.',
-				error: 'Not Found',
+				detail: '파티에서 ID가 2인 멤버를 찾을 수 없습니다.',
+				timestamp: '2025-06-30T12:00:00.000Z',
+				path: '/parties/1/members/2',
 			},
 		},
 	})
@@ -197,6 +219,8 @@ export class PartyMembersController {
 	}
 
 	@Put('/leader/:userId')
+	@ApiBearerAuth()
+	@UseGuards(JwtAuthGuard)
 	@ApiOperation({ summary: '파티장 권한 이양 (파티장만)' })
 	@ApiOkResponse({
 		description: '파티장을 변경했습니다.',
@@ -206,23 +230,38 @@ export class PartyMembersController {
 		description: '자기 자신에게 권한을 이양할 수 없습니다.',
 		schema: {
 			example: {
+				success: false,
 				statusCode: 400,
+				errorCode: 'p-010',
 				message: '자기 자신에게 권한을 이양할 수 없습니다.',
-				error: 'Bad Request',
+				detail: '파티장은 자기 자신에게 리더 권한을 넘길 수 없습니다.',
+				timestamp: '2025-06-30T12:00:00.000Z',
+				path: '/parties/1/leader/1',
 			},
 		},
 	})
 	@ApiUnauthorizedResponse({
 		description: '인증이 필요합니다.',
-		schema: { example: { statusCode: 401, message: 'Unauthorized' } },
+		schema: {
+			example: {
+				success: false,
+				statusCode: 401,
+				errorCode: 'u-001',
+				message: '인증이 필요합니다.',
+			},
+		},
 	})
 	@ApiForbiddenResponse({
 		description: '파티장만 권한을 이양할 수 있습니다.',
 		schema: {
 			example: {
+				success: false,
 				statusCode: 403,
-				message: '파티장만 권한을 이양할 수 있습니다.',
-				error: 'Forbidden',
+				errorCode: 'p-002',
+				message: '파티장만 이 작업을 수행할 수 있습니다.',
+				detail: '오직 파티장만 리더를 변경할 수 있습니다.',
+				timestamp: '2025-06-30T12:00:00.000Z',
+				path: '/parties/1/leader/2',
 			},
 		},
 	})
@@ -230,9 +269,13 @@ export class PartyMembersController {
 		description: '파티나 멤버를 찾을 수 없습니다.',
 		schema: {
 			example: {
+				success: false,
 				statusCode: 404,
+				errorCode: 'p-007',
 				message: '해당 멤버를 찾을 수 없습니다.',
-				error: 'Not Found',
+				detail: '파티에서 ID가 2인 멤버를 찾을 수 없습니다.',
+				timestamp: '2025-06-30T12:00:00.000Z',
+				path: '/parties/1/leader/2',
 			},
 		},
 	})

--- a/src/parties/controllers/party-members.controller.ts
+++ b/src/parties/controllers/party-members.controller.ts
@@ -92,7 +92,7 @@ export class PartyMembersController {
 		return { message: `${username}님이 파티에 참가했습니다.` };
 	}
 
-	@Delete('/me')
+	@Delete()
 	@ApiBearerAuth()
 	@UseGuards(JwtAuthGuard)
 	@ApiOperation({ summary: '파티 탈퇴' })
@@ -111,7 +111,7 @@ export class PartyMembersController {
 					message: '파티장은 파티를 떠날 수 없습니다.',
 					detail: '파티장을 다른 멤버에게 위임한 후 떠나주세요.',
 					timestamp: '2025-07-03T10:00:00.000Z',
-					path: '/parties/1/members/me',
+					path: '/parties/1/members',
 				},
 			},
 		},
@@ -127,7 +127,7 @@ export class PartyMembersController {
 					message: '인증되지 않은 사용자입니다.',
 					detail: '유효한 인증 토큰이 제공되지 않았습니다.',
 					timestamp: '2025-07-03T10:00:00.000Z',
-					path: '/parties/1/members/me',
+					path: '/parties/1/members',
 				},
 			},
 		},
@@ -143,7 +143,7 @@ export class PartyMembersController {
 					message: '파티 멤버를 찾을 수 없습니다.',
 					detail: '해당 사용자는 이 파티의 멤버가 아닙니다.',
 					timestamp: '2025-07-03T10:00:00.000Z',
-					path: '/parties/1/members/me',
+					path: '/parties/1/members',
 				},
 			},
 		},

--- a/src/parties/controllers/party-members.controller.ts
+++ b/src/parties/controllers/party-members.controller.ts
@@ -55,17 +55,31 @@ export class PartyMembersController {
 		},
 	})
 	@ApiUnauthorizedResponse({
-		description: '인증이 필요합니다.',
-		schema: { example: { statusCode: 401, message: 'Unauthorized' } },
+		description: '인증되지 않은 사용자입니다.',
+		content: {
+			'application/json': {
+				example: {
+					success: false,
+					statusCode: 401,
+					errorCode: 'a-002',
+					message: '인증되지 않은 사용자입니다.',
+					detail: '유효한 인증 토큰이 제공되지 않았습니다.',
+					timestamp: '2025-07-03T10:00:00.000Z',
+					path: '/parties/1/members',
+				},
+			},
+		},
 	})
 	@ApiNotFoundResponse({
 		description: '파티를 찾을 수 없습니다.',
-		schema: {
-			example: {
-				success: false,
-				statusCode: 404,
-				errorCode: 'p-001',
-				message: '파티를 찾을 수 없습니다.',
+		content: {
+			'application/json': {
+				example: {
+					success: false,
+					statusCode: 404,
+					errorCode: 'p-001',
+					message: '파티를 찾을 수 없습니다.',
+				},
 			},
 		},
 	})
@@ -86,27 +100,51 @@ export class PartyMembersController {
 		description: '파티에서 탈퇴했습니다.',
 		schema: { example: { message: 'user1님이 파티에서 탈퇴했습니다.' } },
 	})
-	@ApiBadRequestResponse({
+	@ApiForbiddenResponse({
 		description: '파티장은 탈퇴할 수 없습니다.',
-		schema: {
-			example: {
-				statusCode: 400,
-				message: '파티장은 탈퇴할 수 없습니다.',
-				error: 'Bad Request',
+		content: {
+			'application/json': {
+				example: {
+					success: false,
+					statusCode: 403,
+					errorCode: 'p-005',
+					message: '파티장은 파티를 떠날 수 없습니다.',
+					detail: '파티장을 다른 멤버에게 위임한 후 떠나주세요.',
+					timestamp: '2025-07-03T10:00:00.000Z',
+					path: '/parties/1/members/me',
+				},
 			},
 		},
 	})
 	@ApiUnauthorizedResponse({
-		description: '인증이 필요합니다.',
-		schema: { example: { statusCode: 401, message: 'Unauthorized' } },
+		description: '인증되지 않은 사용자입니다.',
+		content: {
+			'application/json': {
+				example: {
+					success: false,
+					statusCode: 401,
+					errorCode: 'a-002',
+					message: '인증되지 않은 사용자입니다.',
+					detail: '유효한 인증 토큰이 제공되지 않았습니다.',
+					timestamp: '2025-07-03T10:00:00.000Z',
+					path: '/parties/1/members/me',
+				},
+			},
+		},
 	})
 	@ApiNotFoundResponse({
-		description: '파티에 참가하지 않았습니다.',
-		schema: {
-			example: {
-				statusCode: 404,
-				message: '파티에 참가하지 않았습니다.',
-				error: 'Not Found',
+		description: '파티 멤버를 찾을 수 없습니다. (파티에 참가하지 않은 경우)',
+		content: {
+			'application/json': {
+				example: {
+					success: false,
+					statusCode: 404,
+					errorCode: 'p-006',
+					message: '파티 멤버를 찾을 수 없습니다.',
+					detail: '해당 사용자는 이 파티의 멤버가 아닙니다.',
+					timestamp: '2025-07-03T10:00:00.000Z',
+					path: '/parties/1/members/me',
+				},
 			},
 		},
 	})
@@ -126,19 +164,33 @@ export class PartyMembersController {
 	@ApiBearerAuth()
 	@UseGuards(JwtAuthGuard)
 	@ApiOperation({ summary: '파티 멤버 목록 조회' })
-	@ApiOkResponse({ description: '파티 멤버 목록을 반환합니다.' })
+	@ApiOkResponse({ description: '파티 멤버 목록을 반환합니다.', type: MemberListResponseDto })
 	@ApiUnauthorizedResponse({
-		description: '인증이 필요합니다.',
-		schema: { example: { statusCode: 401, message: 'Unauthorized' } },
+		description: '인증되지 않은 사용자입니다.',
+		content: {
+			'application/json': {
+				example: {
+					success: false,
+					statusCode: 401,
+					errorCode: 'a-002',
+					message: '인증되지 않은 사용자입니다.',
+					detail: '유효한 인증 토큰이 제공되지 않았습니다.',
+					timestamp: '2025-07-03T10:00:00.000Z',
+					path: '/parties/1/members',
+				},
+			},
+		},
 	})
 	@ApiNotFoundResponse({
 		description: '파티를 찾을 수 없습니다.',
-		schema: {
-			example: {
-				success: false,
-				statusCode: 404,
-				errorCode: 'p-001',
-				message: '파티를 찾을 수 없습니다.',
+		content: {
+			'application/json': {
+				example: {
+					success: false,
+					statusCode: 404,
+					errorCode: 'p-001',
+					message: '파티를 찾을 수 없습니다.',
+				},
 			},
 		},
 	})
@@ -171,41 +223,63 @@ export class PartyMembersController {
 		},
 	})
 	@ApiUnauthorizedResponse({
-		description: '인증이 필요합니다.',
-		schema: {
-			example: {
-				success: false,
-				statusCode: 401,
-				errorCode: 'u-001',
-				message: '인증이 필요합니다.',
+		description: '인증되지 않은 사용자입니다.',
+		content: {
+			'application/json': {
+				example: {
+					success: false,
+					statusCode: 401,
+					errorCode: 'a-002',
+					message: '인증되지 않은 사용자입니다.',
+					detail: '유효한 인증 토큰이 제공되지 않았습니다.',
+					timestamp: '2025-07-03T10:00:00.000Z',
+					path: '/parties/1/members/2',
+				},
 			},
 		},
 	})
 	@ApiForbiddenResponse({
 		description: '파티장만 강퇴할 수 있습니다.',
-		schema: {
-			example: {
-				success: false,
-				statusCode: 403,
-				errorCode: 'p-002',
-				message: '파티장만 이 작업을 수행할 수 있습니다.',
-				detail: '오직 파티장만 멤버를 강퇴할 수 있습니다.',
-				timestamp: '2025-06-30T12:00:00.000Z',
-				path: '/parties/1/members/2',
+		content: {
+			'application/json': {
+				example: {
+					success: false,
+					statusCode: 403,
+					errorCode: 'p-002',
+					message: '파티장만 이 작업을 수행할 수 있습니다.',
+					detail: '오직 파티장만 멤버를 강퇴할 수 있습니다.',
+					timestamp: '2025-06-30T12:00:00.000Z',
+					path: '/parties/1/members/2',
+				},
 			},
 		},
 	})
 	@ApiNotFoundResponse({
 		description: '파티나 멤버를 찾을 수 없습니다.',
-		schema: {
-			example: {
-				success: false,
-				statusCode: 404,
-				errorCode: 'p-007',
-				message: '해당 멤버를 찾을 수 없습니다.',
-				detail: '파티에서 ID가 2인 멤버를 찾을 수 없습니다.',
-				timestamp: '2025-06-30T12:00:00.000Z',
-				path: '/parties/1/members/2',
+		content: {
+			'application/json': {
+				examples: {
+					'파티 없음': {
+						value: {
+							success: false,
+							statusCode: 404,
+							errorCode: 'p-001',
+							message: '파티를 찾을 수 없습니다.',
+							timestamp: '2025-07-03T10:00:00.000Z',
+							path: '/parties/999/members/2',
+						},
+					},
+					'멤버 없음': {
+						value: {
+							success: false,
+							statusCode: 404,
+							errorCode: 'p-009',
+							message: '해당 유저는 파티 멤버가 아닙니다.',
+							timestamp: '2025-07-03T10:00:00.000Z',
+							path: '/parties/1/members/999',
+						},
+					},
+				},
 			},
 		},
 	})
@@ -241,41 +315,63 @@ export class PartyMembersController {
 		},
 	})
 	@ApiUnauthorizedResponse({
-		description: '인증이 필요합니다.',
-		schema: {
-			example: {
-				success: false,
-				statusCode: 401,
-				errorCode: 'u-001',
-				message: '인증이 필요합니다.',
+		description: '인증되지 않은 사용자입니다.',
+		content: {
+			'application/json': {
+				example: {
+					success: false,
+					statusCode: 401,
+					errorCode: 'a-002',
+					message: '인증되지 않은 사용자입니다.',
+					detail: '유효한 인증 토큰이 제공되지 않았습니다.',
+					timestamp: '2025-07-03T10:00:00.000Z',
+					path: '/parties/1/members/leader',
+				},
 			},
 		},
 	})
 	@ApiForbiddenResponse({
-		description: '파티장만 권한을 이양할 수 있습니다.',
-		schema: {
-			example: {
-				success: false,
-				statusCode: 403,
-				errorCode: 'p-002',
-				message: '파티장만 이 작업을 수행할 수 있습니다.',
-				detail: '오직 파티장만 리더를 변경할 수 있습니다.',
-				timestamp: '2025-06-30T12:00:00.000Z',
-				path: '/parties/1/leader/2',
+		description: '파티장만 위임할 수 있습니다.',
+		content: {
+			'application/json': {
+				example: {
+					success: false,
+					statusCode: 403,
+					errorCode: 'p-002',
+					message: '파티장만 이 작업을 수행할 수 있습니다.',
+					detail: '오직 파티장만 리더를 변경할 수 있습니다.',
+					timestamp: '2025-06-30T12:00:00.000Z',
+					path: '/parties/1/members/leader',
+				},
 			},
 		},
 	})
 	@ApiNotFoundResponse({
 		description: '파티나 멤버를 찾을 수 없습니다.',
-		schema: {
-			example: {
-				success: false,
-				statusCode: 404,
-				errorCode: 'p-007',
-				message: '해당 멤버를 찾을 수 없습니다.',
-				detail: '파티에서 ID가 2인 멤버를 찾을 수 없습니다.',
-				timestamp: '2025-06-30T12:00:00.000Z',
-				path: '/parties/1/leader/2',
+		content: {
+			'application/json': {
+				examples: {
+					'파티 없음': {
+						value: {
+							success: false,
+							statusCode: 404,
+							errorCode: 'p-001',
+							message: '파티를 찾을 수 없습니다.',
+							timestamp: '2025-07-03T10:00:00.000Z',
+							path: '/parties/999/members/leader',
+						},
+					},
+					'멤버 없음': {
+						value: {
+							success: false,
+							statusCode: 404,
+							errorCode: 'p-009',
+							message: '해당 유저는 파티 멤버가 아닙니다.',
+							timestamp: '2025-07-03T10:00:00.000Z',
+							path: '/parties/1/members/leader',
+						},
+					},
+				},
 			},
 		},
 	})

--- a/src/parties/dto/party-with-members.dto.ts
+++ b/src/parties/dto/party-with-members.dto.ts
@@ -18,6 +18,9 @@ export class PartyMemberSummaryDto {
 
 	@ApiProperty({ required: false })
 	leftAt?: Date;
+
+	@ApiProperty({ example: 'pro_gamer123', description: '게임 내 닉네임' })
+	gameUsername: string;
 }
 
 // 파티에서만 사용하는 생성자 정보 DTO (password 등 민감 정보 제외)

--- a/src/parties/dto/response.dto.ts
+++ b/src/parties/dto/response.dto.ts
@@ -62,11 +62,6 @@ export class PartyListItemDto {
 	currentMemberCount: number;
 }
 
-export class UserGameProfileDto {
-	@ApiProperty({ example: 'player123' })
-	gameUsername: string;
-}
-
 export class PartyMemberDetailDto {
 	@ApiProperty({ example: 1 })
 	id: number; // PartyMembers.id
@@ -83,8 +78,8 @@ export class PartyMemberDetailDto {
 	@ApiProperty({ example: '2025-06-27T09:00:00+09:00' })
 	joinedAt: string;
 
-	@ApiProperty({ type: () => UserGameProfileDto })
-	userGameProfile: UserGameProfileDto;
+	@ApiProperty({ example: 'player123', description: '게임 내 닉네임' })
+	gameUsername: string;
 }
 
 // 기본 파티 정보 DTO (재사용 가능)

--- a/src/parties/services/parties.service.ts
+++ b/src/parties/services/parties.service.ts
@@ -116,7 +116,7 @@ export class PartiesService {
 			// 리더의 게임 프로필을 명확히 조회하여 맵에 포함
 			const leaderUserId = creatorId;
 			const leaderGameId = dto.gameId;
-			const leaderProfile = userGameProfile as { gameUsername: string; id: number }; // 타입 단언 추가
+                        const leaderProfile = userGameProfile;
 			const userGameProfilesMap = new Map<string, string>();
 			if (leaderProfile && leaderProfile.gameUsername) {
 				userGameProfilesMap.set(

--- a/src/parties/services/parties.service.ts
+++ b/src/parties/services/parties.service.ts
@@ -42,7 +42,7 @@ export class PartiesService {
 			const creator = await queryRunner.manager.findOneBy(User, { id: creatorId });
 			if (!creator) throw new AppException(ErrorCode.USER_NOT_FOUND);
 
-			let userGameProfile: { id: number }; // 타입을 명확히 지정
+                        let userGameProfile: UserGameProfile; // 타입을 명확히 지정
 			if (dto.profileId) {
 				const profile = await this.userGameProfilesService.getUserGameProfileById(
 					dto.profileId,

--- a/src/parties/services/parties.service.ts
+++ b/src/parties/services/parties.service.ts
@@ -42,19 +42,20 @@ export class PartiesService {
 			const creator = await queryRunner.manager.findOneBy(User, { id: creatorId });
 			if (!creator) throw new AppException(ErrorCode.USER_NOT_FOUND);
 
-			let userGameProfile;
+			let userGameProfile: { id: number }; // 타입을 명확히 지정
 			if (dto.profileId) {
-				userGameProfile = await this.userGameProfilesService.getUserGameProfileById(
+				const profile = await this.userGameProfilesService.getUserGameProfileById(
 					dto.profileId,
 					creatorId,
 					dto.gameId,
 				);
-				if (!userGameProfile) {
+				if (!profile) {
 					throw new AppException(
 						ErrorCode.USER_GAME_PROFILE_NOT_FOUND,
 						'선택한 게임 프로필이 존재하지 않습니다.',
 					);
 				}
+				userGameProfile = profile;
 			} else if (dto.gameUsername) {
 				userGameProfile = await this.userGameProfilesService.findOrCreateUserGameProfile(
 					creatorId,
@@ -92,6 +93,7 @@ export class PartiesService {
 				partyId: newParty.id,
 				userId: creatorId,
 				isLeader: true,
+				userGameProfileId: userGameProfile.id, // 생성자의 게임 프로필 ID 저장
 			});
 			await queryRunner.manager.save(partyMember);
 
@@ -114,7 +116,7 @@ export class PartiesService {
 			// 리더의 게임 프로필을 명확히 조회하여 맵에 포함
 			const leaderUserId = creatorId;
 			const leaderGameId = dto.gameId;
-			const leaderProfile = userGameProfile as { gameUsername: string };
+			const leaderProfile = userGameProfile as { gameUsername: string; id: number }; // 타입 단언 추가
 			const userGameProfilesMap = new Map<string, string>();
 			if (leaderProfile && leaderProfile.gameUsername) {
 				userGameProfilesMap.set(

--- a/src/parties/services/party-members.service.ts
+++ b/src/parties/services/party-members.service.ts
@@ -210,7 +210,7 @@ export class PartyMembersService {
 				username: member.user?.username || '',
 				isLeader: member.isLeader,
 				joinedAt: member.joinedAt?.toISOString(),
-				userGameProfile: { gameUsername },
+				gameUsername: gameUsername,
 			};
 		});
 


### PR DESCRIPTION
## Parties/PartyMembers API 커스텀 에러코드 및 Swagger 문서 일관성 개선

### 주요 변경사항
- 서비스 로직에서 사용하는 커스텀 에러코드(`p-006` 등)와 Swagger 문서의 에러 응답 예시를 실제 서비스와 완전히 일치하도록 통일
- 파티 탈퇴 시 "파티에 참가하지 않은 경우" → `p-006`(PARTY_MEMBER_NOT_FOUND) 코드로 명확하게 표기
- 파티장 탈퇴 시 400 → 403(Forbidden) 및 `p-005` 코드로 일관성 있게 수정
- 모든 인증/권한 관련 Swagger 예시를 커스텀 포맷(`success`, `statusCode`, `errorCode`, `detail`, `timestamp`, `path`)으로 통일
- 기타 Swagger 문서 누락/불일치 부분 보강

### 기타
- 서비스 로직과 문서가 완전히 일치하도록 점검 및 리팩토링
- Prettier, ESLint 등