### PR TITLE
리프레쉬 토큰 및 토큰 관련 에러코드 기능 수정

### DIFF
--- a/src/auth/controllers/auth.controller.ts
+++ b/src/auth/controllers/auth.controller.ts
@@ -70,13 +70,30 @@ export class AuthController {
 	@ApiResponse({ status: 200, description: '토큰 갱신 성공', type: RefreshTokenResponseDto })
 	@ApiResponse({ status: 401, description: '리프레시 토큰 유효하지 않음', type: TokenErrorResponseDto })
 	@ApiCookieAuth('refreshToken')
-	async refreshToken(@Req() req: Request) {
+	async refreshToken(@Req() req: Request, @Res({ passthrough: true }) res: Response) {
 		const refreshToken = req.cookies?.refreshToken;
 		if (!refreshToken) {
             throw new AppException(ErrorCode.REFRESH_TOKEN_INVALID);
         }
 
-		return await this.authService.refreshAccessToken({refreshToken});
+		try {
+			return await this.authService.refreshAccessToken({refreshToken});
+		} catch (error) {
+			// 리프레시 토큰 만료 시 쿠키 삭제
+			if (error instanceof AppException && error.getResponse()['errorCode'] === ErrorCode.REFRESH_TOKEN_EXPIRED) {
+				// 쿠키 삭제
+				res.clearCookie('refreshToken', {
+					httpOnly: true,
+					secure: false,
+					path: '/api/auth/refresh',
+					sameSite: 'strict'
+				});
+				
+				// 에러는 그대로 전파하여 클라이언트에게 만료 메시지 전달
+				throw error;
+			}
+			throw error;
+		}
 	}
 
 	@Get('nicknameCheck')

--- a/src/auth/guards/jwt-auth.guard.ts
+++ b/src/auth/guards/jwt-auth.guard.ts
@@ -1,5 +1,26 @@
-import { Injectable } from '@nestjs/common';
+import { ExecutionContext, Injectable } from '@nestjs/common';
+import { JsonWebTokenError, TokenExpiredError } from '@nestjs/jwt';
 import { AuthGuard } from '@nestjs/passport';
+import { ErrorCode } from 'src/common/constants/error-codes';
+import { AppException } from 'src/common/exceptions/app.exception';
 
 @Injectable()
-export class JwtAuthGuard extends AuthGuard('jwt') {}
+export class JwtAuthGuard extends AuthGuard('jwt') {
+    handleRequest<TUser = any>(err: any, user: any, info: any, context: ExecutionContext, status?: any): TUser {
+        // 토큰 관련 오류 처리
+        if (info instanceof TokenExpiredError) {
+            throw new AppException(ErrorCode.ACCESS_TOKEN_EXPIRED);
+        }
+      
+        if (info instanceof JsonWebTokenError) {
+            throw new AppException(ErrorCode.UNAUTHORIZED);
+        }
+
+        // 기본 오류 처리
+        if (err || !user) {
+            throw err || new AppException(ErrorCode.UNAUTHORIZED);
+        }
+
+        return user;
+    }
+}

--- a/src/auth/services/auth.service.ts
+++ b/src/auth/services/auth.service.ts
@@ -74,11 +74,12 @@ export class AuthService {
 	/* 토큰 생성 (액세스 토큰 + 리프레시 토큰) */
 	async generateTokens(payload: { id: number; username: string; email: string }) {
 		// 액세스 토큰 생성
-		const jwt_expires_in = process.env.JWT_EXPIRES_IN || '15m';
+		const jwt_expires_in = process.env.JWT_EXPIRES_IN ?? '15m';
 		const accessToken = await this.generateToken(payload, jwt_expires_in);
 
 		// 리프레시 토큰 생성
-		const jwt_refresh_expires_in = process.env.JWT_REFRESH_EXPIRES_IN || '7d';
+		console.log(process.env.JWT_REFRESH_EXPIRES_IN)
+		const jwt_refresh_expires_in = process.env.JWT_REFRESH_EXPIRES_IN ?? '7d';
 		const refreshToken = await this.generateToken(payload, jwt_refresh_expires_in);
 
 		// 리프레시 토큰 데이터베이스에 저장
@@ -94,7 +95,7 @@ export class AuthService {
 		try {
 			// 리프레시 토큰 검증
 			const payload = this.jwtService.verify(refreshToken, {
-				secret: process.env.JWT_SECRET || 'gamePartySecretKey'
+				secret: process.env.JWT_SECRET ?? 'gamePartySecretKey'
 			});
 			
 			// 사용자 조회
@@ -125,6 +126,22 @@ export class AuthService {
 
 			// JWT 검증 오류 처리
 			if (error.name === 'TokenExpiredError') {
+				try {
+					// 만료된 토큰에서 페이로드 추출 (verify 옵션에서 만료 검증 무시)
+					const decodedToken = this.jwtService.decode(refreshToken);
+					if (decodedToken && typeof decodedToken === 'object' && decodedToken.email) {
+						// 사용자 찾기
+						const user = await this.userRepository.findOneBy({ email: decodedToken.email });
+						if (user) {
+							// 리프레시 토큰 삭제
+							await this.userRepository.update(user.id, { refreshToken: '' });
+						}
+					}
+				} catch (decodeError) {
+					// 디코딩 실패 시 무시하고 계속 진행
+					console.error('Failed to decode expired token:', decodeError);
+				}
+				
 				throw new AppException(ErrorCode.REFRESH_TOKEN_EXPIRED);
 			}
 			

--- a/src/auth/services/auth.service.ts
+++ b/src/auth/services/auth.service.ts
@@ -78,7 +78,6 @@ export class AuthService {
 		const accessToken = await this.generateToken(payload, jwt_expires_in);
 
 		// 리프레시 토큰 생성
-		console.log(process.env.JWT_REFRESH_EXPIRES_IN)
 		const jwt_refresh_expires_in = process.env.JWT_REFRESH_EXPIRES_IN ?? '7d';
 		const refreshToken = await this.generateToken(payload, jwt_refresh_expires_in);
 

--- a/src/auth/strategies/jwt.strategy.ts
+++ b/src/auth/strategies/jwt.strategy.ts
@@ -16,10 +16,13 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
 		super({
 			jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
 			ignoreExpiration: false,
-			secretOrKey: process.env.JWT_SECRET || 'gamePartySecretKey',
+			secretOrKey: process.env.JWT_SECRET ?? 'gamePartySecretKey',
 		});
 	}
 
+	/**
+	 * validate메서드는 토큰의 유효성을 검사하는 것이 아닌, 토큰이 유효하다면 토큰에 포함된 사용자 정보를 반환하는 역할을 합니다.
+	 */
 	async validate(payload: any) {
 		try {
 			const { email } = payload;
@@ -31,18 +34,8 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
 			}
 
 			return { id: user.id, email: user.email };
+
 		} catch (error) {
-			// 토큰 만료 오류 처리
-			if (error.name === 'TokenExpiredError') {
-				throw new AppException(ErrorCode.ACCESS_TOKEN_EXPIRED);
-			}
-			
-			// 토큰 검증 오류 처리
-			if (error.name === 'JsonWebTokenError') {
-				throw new AppException(ErrorCode.UNAUTHORIZED);
-			}
-			
-			// 기타 오류는 그대로 전파
 			throw error;
 		}
 	}

--- a/src/users/controllers/users.controller.ts
+++ b/src/users/controllers/users.controller.ts
@@ -14,6 +14,8 @@ import {
 	DeleteAccountResponseDto,
 	UsersErrorResponseDto,
 	PasswordErrorResponseDto,
+	UserAlreadyExistsResponseDto,
+	EmailAlreadyExistsResponseDto,
 } from '../dto';
 
 @ApiTags('users')
@@ -30,7 +32,7 @@ export class UsersController {
 		description: '사용자 정보 조회 성공',
 		type: UserProfileResponseDto,
 	})
-	@ApiResponse({ status: 404, description: '사용자를 찾을 수 없음', type: UsersErrorResponseDto })
+	@ApiResponse({ status: 401, description: '사용자를 찾을 수 없음', type: UsersErrorResponseDto })
 	async getProfile(@GetUser() jwtPayload: JwtPayload) {
 		const userId = jwtPayload.id; // JWT에서 추출된 사용자 ID
 		const user = await this.usersService.getProfile(userId);
@@ -47,7 +49,9 @@ export class UsersController {
 		description: '사용자 정보 수정 성공',
 		type: UpdateProfileResponseDto,
 	})
-	@ApiResponse({ status: 404, description: '사용자를 찾을 수 없음', type: UsersErrorResponseDto })
+	@ApiResponse({ status: 401, description: '사용자를 찾을 수 없음', type: UsersErrorResponseDto })
+	@ApiResponse({ status: 401, description: '이미 사용 중인 사용자 이름입니다.', type: UserAlreadyExistsResponseDto })
+	@ApiResponse({ status: 409, description: '이미 존재하는 이메일입니다.', type: EmailAlreadyExistsResponseDto })
 	async updateProfile(@GetUser() jwtPayload: JwtPayload, @Body() updateUserDto: UpdateUserDto) {
 		const userId = jwtPayload.id; // JWT에서 추출된 사용자 ID
 		await this.usersService.updateProfile(userId, updateUserDto);
@@ -62,7 +66,7 @@ export class UsersController {
 		type: ChangePasswordResponseDto,
 	})
 	@ApiResponse({
-		status: 400,
+		status: 401,
 		description: '현재 비밀번호가 일치하지 않음',
 		type: PasswordErrorResponseDto,
 	})

--- a/src/users/dto/response.dto.ts
+++ b/src/users/dto/response.dto.ts
@@ -49,12 +49,36 @@ export class UsersErrorResponseDto {
 }
 
 export class PasswordErrorResponseDto {
-	@ApiProperty({ example: 400 })
+	@ApiProperty({ example: 401 })
 	statusCode: number;
 
 	@ApiProperty({ example: '현재 비밀번호가 일치하지 않습니다.' })
 	message: string;
 
-	@ApiProperty({ example: 'Bad Request' })
+	@ApiProperty({ example: 'Unauthorized' })
 	error: string;
 }
+
+export class UserAlreadyExistsResponseDto {
+	@ApiProperty({ example: 401 })
+	statusCode: number;
+
+	@ApiProperty({ example: '이미 사용 중인 사용자 이름입니다.' })
+	message: string;
+
+	@ApiProperty({ example: 'Unauthorized' })
+	error: string;
+}
+
+export class EmailAlreadyExistsResponseDto {
+	@ApiProperty({ example: 409 })
+	statusCode: number;
+
+	@ApiProperty({ example: '이미 사용 중인 이메일입니다.' })
+	message: string;
+
+	@ApiProperty({ example: 'Conflict' })
+	error: string;
+}
+	
+	

--- a/src/users/services/users.service.ts
+++ b/src/users/services/users.service.ts
@@ -5,6 +5,8 @@ import * as bcrypt from 'bcrypt';
 import { User } from '../entities/user.entity';
 import { UpdateUserDto } from '../dto/update-user.dto';
 import { ChangePasswordDto } from '../dto/change-password.dto';
+import { AppException } from 'src/common/exceptions/app.exception';
+import { ErrorCode } from 'src/common/constants/error-codes';
 
 @Injectable()
 export class UsersService {
@@ -19,7 +21,7 @@ export class UsersService {
 	async findById(id: number): Promise<User> {
 		const user = await this.usersRepository.findOne({ where: { id } });
 		if (!user) {
-			throw new NotFoundException('사용자를 찾을 수 없습니다.');
+			throw new AppException(ErrorCode.USER_NOT_FOUND);
 		}
 		return user;
 	}
@@ -30,7 +32,7 @@ export class UsersService {
   async getProfile(userId: number): Promise<User> {
     const user = await this.findById(userId);
     if (!user) {
-      throw new NotFoundException('사용자를 찾을 수 없습니다.');
+      throw new AppException(ErrorCode.USER_NOT_FOUND);
     }
     return user;
   }
@@ -41,7 +43,7 @@ export class UsersService {
   async updateProfile(userId: number, updateUserDto: UpdateUserDto): Promise<User> {
     const user = await this.findById(userId);
     if (!user) {
-      throw new NotFoundException('사용자를 찾을 수 없습니다.');
+      throw new AppException(ErrorCode.USER_NOT_FOUND);
     }
     
     // 업데이트할 필드가 있는 경우에만 업데이트
@@ -62,7 +64,7 @@ export class UsersService {
         where: { email: updateUserDto.email } 
       });
       if (existingUser && existingUser.id !== userId) {
-        throw new UnauthorizedException('이미 사용 중인 이메일입니다.');
+        throw new AppException(ErrorCode.USER_ALREADY_EXISTS);
       }
       user.email = updateUserDto.email;
     }
@@ -86,7 +88,7 @@ export class UsersService {
     );
     
     if (!isPasswordValid) {
-      throw new BadRequestException('현재 비밀번호가 일치하지 않습니다.');
+      throw new AppException(ErrorCode.INVALID_PASSWORD);
     }
     
     // 새 비밀번호 해싱


### PR DESCRIPTION
### 기능 구현
- 리프레쉬 토큰 기한 만료 시 자동으로 로그아웃
    - 쿠키 삭제
    - DB의 리프레쉬 토큰 삭제

### 기능 수정
- `JwtAuthGuard` 클래스에서 액세스 토큰 기한 만기 시 `a-003` 에러코드를 응답하도록 수정
- 그 외에 인증, 인가, 유저 관련 api에서 적절한 에러코드를 응답하도록 수정

### for Gemini
- Please respond in Korean during code reviews.