### PR TITLE
파티/파티원 API 기능 개선 및 Swagger 문서 그룹/에러 응답 일관성 강화

### DIFF
--- a/src/parties/controllers/parties.controller.ts
+++ b/src/parties/controllers/parties.controller.ts
@@ -120,6 +120,32 @@ export class PartiesController {
 		return this.partiesService.createParty(createPartyDto, user.id);
 	}
 
+	@Get('me')
+	@ApiOperation({ summary: '내가 참여한 파티 목록 조회' })
+	@ApiOkResponse({
+		description: '사용자가 참여한 파티 목록을 반환합니다.',
+		type: [PartyListItemDto],
+	})
+	@ApiUnauthorizedResponse({
+		description: '인증되지 않은 사용자입니다.',
+		content: {
+			'application/json': {
+				example: {
+					success: false,
+					statusCode: 401,
+					errorCode: 'a-002',
+					message: '인증되지 않은 사용자입니다.',
+					detail: '유효한 인증 토큰이 제공되지 않았습니다.',
+					timestamp: '2025-07-03T10:00:00.000Z',
+					path: '/parties/me',
+				},
+			},
+		},
+	})
+	async findMyParties(@GetUser() user: { id: number }): Promise<PartyListItemDto[]> {
+		return this.partiesService.findUserParties(user.id);
+	}
+
 	@Get(':id')
 	@ApiOperation({ summary: '특정 파티 조회' })
 	@ApiOkResponse({ description: '파티 + 멤버 정보를 반환합니다.', type: PartyWithMembersDto })

--- a/src/parties/controllers/parties.controller.ts
+++ b/src/parties/controllers/parties.controller.ts
@@ -66,7 +66,22 @@ export class PartiesController {
 			},
 		},
 	})
-	@ApiUnauthorizedResponse({ description: '인증되지 않은 사용자입니다.' })
+	@ApiUnauthorizedResponse({
+		description: '인증되지 않은 사용자입니다.',
+		content: {
+			'application/json': {
+				example: {
+					success: false,
+					statusCode: 401,
+					errorCode: 'a-002',
+					message: '인증되지 않은 사용자입니다.',
+					detail: '유효한 인증 토큰이 제공되지 않았습니다.',
+					timestamp: '2025-07-03T10:00:00.000Z',
+					path: '/parties',
+				},
+			},
+		},
+	})
 	@ApiNotFoundResponse({
 		description: '존재하지 않는 리소스입니다. (e.g. 게임, 사용자, 게임 프로필)',
 		content: {
@@ -108,7 +123,22 @@ export class PartiesController {
 	@Get(':id')
 	@ApiOperation({ summary: '특정 파티 조회' })
 	@ApiOkResponse({ description: '파티 + 멤버 정보를 반환합니다.', type: PartyWithMembersDto })
-	@ApiUnauthorizedResponse({ description: '인증되지 않은 사용자입니다.' })
+	@ApiUnauthorizedResponse({
+		description: '인증되지 않은 사용자입니다.',
+		content: {
+			'application/json': {
+				example: {
+					success: false,
+					statusCode: 401,
+					errorCode: 'a-002',
+					message: '인증되지 않은 사용자입니다.',
+					detail: '유효한 인증 토큰이 제공되지 않았습니다.',
+					timestamp: '2025-07-03T10:00:00.000Z',
+					path: '/parties/1',
+				},
+			},
+		},
+	})
 	@ApiNotFoundResponse({
 		description: '파티를 찾을 수 없습니다.',
 		content: {
@@ -151,7 +181,22 @@ export class PartiesController {
 			},
 		},
 	})
-	@ApiUnauthorizedResponse({ description: '인증되지 않은 사용자입니다.' })
+	@ApiUnauthorizedResponse({
+		description: '인증되지 않은 사용자입니다.',
+		content: {
+			'application/json': {
+				example: {
+					success: false,
+					statusCode: 401,
+					errorCode: 'a-002',
+					message: '인증되지 않은 사용자입니다.',
+					detail: '유효한 인증 토큰이 제공되지 않았습니다.',
+					timestamp: '2025-07-03T10:00:00.000Z',
+					path: '/parties/1',
+				},
+			},
+		},
+	})
 	@ApiForbiddenResponse({
 		description: '권한이 없습니다.',
 		content: {
@@ -211,10 +256,29 @@ export class PartiesController {
 	@ApiOperation({ summary: '파티 삭제' })
 	@ApiOkResponse({
 		description: '파티가 성공적으로 삭제되었습니다.',
-		schema: { example: { message: '파티가 성공적으로 삭제되었습니다.' } },
+		content: {
+			'application/json': {
+				example: { message: '파티가 성공적으로 삭제되었습니다.' },
+			},
+		},
 	})
 	@HttpCode(HttpStatus.OK) // 성공 시 200 OK
-	@ApiUnauthorizedResponse({ description: '인증되지 않은 사용자입니다.' })
+	@ApiUnauthorizedResponse({
+		description: '인증되지 않은 사용자입니다.',
+		content: {
+			'application/json': {
+				example: {
+					success: false,
+					statusCode: 401,
+					errorCode: 'a-002',
+					message: '인증되지 않은 사용자입니다.',
+					detail: '유효한 인증 토큰이 제공되지 않았습니다.',
+					timestamp: '2025-07-03T10:00:00.000Z',
+					path: '/parties/1',
+				},
+			},
+		},
+	})
 	@ApiForbiddenResponse({
 		description: '파티 생성자만 삭제할 수 있습니다.',
 		content: {
@@ -259,33 +323,22 @@ export class PartiesController {
 	@ApiOperation({ summary: '파티 목록 조회' })
 	@ApiOkResponse({
 		description: '파티 목록을 반환합니다.',
-		type: PartyListItemDto,
-		isArray: true,
-		schema: {
-			example: [
-				{
-					id: 1,
-					title: '같이 즐겁게 게임해요',
-					gameId: 1,
-					gameBannerUrl:
-						'https://cdn.cloudflare.steamstatic.com/steam/apps/570/header.jpg',
-					creatorId: 1,
-					purposeTag: '레이드',
-					maxParticipants: 8,
-					description: '파티 설명',
-					isPrivate: false,
-					accessCode: null,
-					isCompleted: false,
-					createdAt: '2025-06-10T18:00:00',
-					updatedAt: '2025-06-10T18:00:00',
-					leader: {
-						userId: 1,
-						username: 'user1',
-						gameUsername: 'pro_gamer123',
-					},
-					currentMemberCount: 3,
+		type: [PartyListItemDto],
+	})
+	@ApiUnauthorizedResponse({
+		description: '인증되지 않은 사용자입니다.',
+		content: {
+			'application/json': {
+				example: {
+					success: false,
+					statusCode: 401,
+					errorCode: 'a-002',
+					message: '인증되지 않은 사용자입니다.',
+					detail: '유효한 인증 토큰이 제공되지 않았습니다.',
+					timestamp: '2025-07-03T10:00:00.000Z',
+					path: '/parties',
 				},
-			],
+			},
 		},
 	})
 	@ApiQuery({ name: 'gameId', required: false, type: Number, description: '게임 ID' })
@@ -313,7 +366,11 @@ export class PartiesController {
 	@ApiOperation({ summary: '파티 완료 처리' })
 	@ApiOkResponse({
 		description: '파티가 완료 처리되었습니다.',
-		schema: { example: { message: '파티가 완료 처리되었습니다.' } },
+		content: {
+			'application/json': {
+				example: { message: '파티가 완료 처리되었습니다.' },
+			},
+		},
 	})
 	@ApiBadRequestResponse({
 		description: '이미 완료된 파티입니다.',
@@ -331,7 +388,22 @@ export class PartiesController {
 			},
 		},
 	})
-	@ApiUnauthorizedResponse({ description: '인증되지 않은 사용자입니다.' })
+	@ApiUnauthorizedResponse({
+		description: '인증되지 않은 사용자입니다.',
+		content: {
+			'application/json': {
+				example: {
+					success: false,
+					statusCode: 401,
+					errorCode: 'a-002',
+					message: '인증되지 않은 사용자입니다.',
+					detail: '유효한 인증 토큰이 제공되지 않았습니다.',
+					timestamp: '2025-07-03T10:00:00.000Z',
+					path: '/parties/1/complete',
+				},
+			},
+		},
+	})
 	@ApiForbiddenResponse({
 		description: '파티 생성자만 완료 처리할 수 있습니다.',
 		content: {

--- a/src/parties/controllers/parties.controller.ts
+++ b/src/parties/controllers/parties.controller.ts
@@ -32,7 +32,7 @@ import {
 import { PartyWithMembersDto } from '../dto/party-with-members.dto';
 import { GetUser } from '../../auth/decorator/get-user.decorator';
 
-@ApiTags('Parties')
+@ApiTags('parties')
 @ApiBearerAuth()
 @UseGuards(JwtAuthGuard)
 @Controller('parties')

--- a/src/parties/controllers/parties.controller.ts
+++ b/src/parties/controllers/parties.controller.ts
@@ -32,7 +32,7 @@ import {
 import { PartyWithMembersDto } from '../dto/party-with-members.dto';
 import { GetUser } from '../../auth/decorator/get-user.decorator';
 
-@ApiTags('parties')
+@ApiTags('Parties')
 @ApiBearerAuth()
 @UseGuards(JwtAuthGuard)
 @Controller('parties')
@@ -142,8 +142,23 @@ export class PartiesController {
 			},
 		},
 	})
-	async findMyParties(@GetUser() user: { id: number }): Promise<PartyListItemDto[]> {
-		return this.partiesService.findUserParties(user.id);
+	@ApiQuery({ name: 'isCompleted', required: false, type: Boolean, description: '완료 여부' })
+	@ApiQuery({ name: 'isPrivate', required: false, type: Boolean, description: '비공개 여부' })
+	@ApiQuery({ name: 'page', required: false, type: Number, description: '페이지 번호' })
+	@ApiQuery({ name: 'limit', required: false, type: Number, description: '페이지 당 개수' })
+	async findMyParties(
+		@GetUser() user: { id: number },
+		@Query('isCompleted') isCompleted?: boolean,
+		@Query('isPrivate') isPrivate?: boolean,
+		@Query('page') page = 1,
+		@Query('limit') limit = 20,
+	): Promise<PartyListItemDto[]> {
+		return this.partiesService.findUserParties(user.id, {
+			isCompleted,
+			isPrivate,
+			page,
+			limit,
+		});
 	}
 
 	@Get(':id')

--- a/src/parties/controllers/parties.controller.ts
+++ b/src/parties/controllers/parties.controller.ts
@@ -32,14 +32,14 @@ import {
 import { PartyWithMembersDto } from '../dto/party-with-members.dto';
 import { GetUser } from '../../auth/decorator/get-user.decorator';
 
-@ApiTags('Parties')
-@ApiBearerAuth()
-@UseGuards(JwtAuthGuard)
+@ApiTags('parties')
 @Controller('parties')
 export class PartiesController {
 	constructor(private readonly partiesService: PartiesService) {}
 
 	@Post()
+	@UseGuards(JwtAuthGuard)
+	@ApiBearerAuth()
 	@ApiOperation({ summary: '파티 생성' })
 	@ApiCreatedResponse({
 		description: '파티가 성공적으로 생성되었습니다.',
@@ -121,6 +121,8 @@ export class PartiesController {
 	}
 
 	@Get('me')
+	@UseGuards(JwtAuthGuard)
+	@ApiBearerAuth()
 	@ApiOperation({ summary: '내가 참여한 파티 목록 조회' })
 	@ApiOkResponse({
 		description: '사용자가 참여한 파티 목록을 반환합니다.',
@@ -164,22 +166,6 @@ export class PartiesController {
 	@Get(':id')
 	@ApiOperation({ summary: '특정 파티 조회' })
 	@ApiOkResponse({ description: '파티 + 멤버 정보를 반환합니다.', type: PartyWithMembersDto })
-	@ApiUnauthorizedResponse({
-		description: '인증되지 않은 사용자입니다.',
-		content: {
-			'application/json': {
-				example: {
-					success: false,
-					statusCode: 401,
-					errorCode: 'a-002',
-					message: '인증되지 않은 사용자입니다.',
-					detail: '유효한 인증 토큰이 제공되지 않았습니다.',
-					timestamp: '2025-07-03T10:00:00.000Z',
-					path: '/parties/1',
-				},
-			},
-		},
-	})
 	@ApiNotFoundResponse({
 		description: '파티를 찾을 수 없습니다.',
 		content: {
@@ -201,6 +187,8 @@ export class PartiesController {
 	}
 
 	@Patch(':id')
+	@UseGuards(JwtAuthGuard)
+	@ApiBearerAuth()
 	@ApiOperation({ summary: '파티 정보 수정' })
 	@ApiOkResponse({
 		description: '수정된 파티 정보를 반환합니다.',
@@ -294,6 +282,8 @@ export class PartiesController {
 	}
 
 	@Delete(':id')
+	@UseGuards(JwtAuthGuard)
+	@ApiBearerAuth()
 	@ApiOperation({ summary: '파티 삭제' })
 	@ApiOkResponse({
 		description: '파티가 성공적으로 삭제되었습니다.',
@@ -366,22 +356,6 @@ export class PartiesController {
 		description: '파티 목록을 반환합니다.',
 		type: [PartyListItemDto],
 	})
-	@ApiUnauthorizedResponse({
-		description: '인증되지 않은 사용자입니다.',
-		content: {
-			'application/json': {
-				example: {
-					success: false,
-					statusCode: 401,
-					errorCode: 'a-002',
-					message: '인증되지 않은 사용자입니다.',
-					detail: '유효한 인증 토큰이 제공되지 않았습니다.',
-					timestamp: '2025-07-03T10:00:00.000Z',
-					path: '/parties',
-				},
-			},
-		},
-	})
 	@ApiQuery({ name: 'gameId', required: false, type: Number, description: '게임 ID' })
 	@ApiQuery({ name: 'isCompleted', required: false, type: Boolean, description: '완료 여부' })
 	@ApiQuery({ name: 'isPrivate', required: false, type: Boolean, description: '비공개 여부' })
@@ -404,6 +378,8 @@ export class PartiesController {
 	}
 
 	@Patch(':id/complete')
+	@UseGuards(JwtAuthGuard)
+	@ApiBearerAuth()
 	@ApiOperation({ summary: '파티 완료 처리' })
 	@ApiOkResponse({
 		description: '파티가 완료 처리되었습니다.',

--- a/src/parties/controllers/parties.controller.ts
+++ b/src/parties/controllers/parties.controller.ts
@@ -9,6 +9,8 @@ import {
 	Patch,
 	Delete,
 	Query,
+	HttpCode,
+	HttpStatus,
 } from '@nestjs/common';
 import { PartiesService } from '../services/parties.service';
 import { CreatePartyDto } from '../dto/create-party.dto';
@@ -30,7 +32,7 @@ import {
 import { PartyWithMembersDto } from '../dto/party-with-members.dto';
 import { GetUser } from '../../auth/decorator/get-user.decorator';
 
-@ApiTags('parties')
+@ApiTags('Parties')
 @ApiBearerAuth()
 @UseGuards(JwtAuthGuard)
 @Controller('parties')
@@ -44,42 +46,55 @@ export class PartiesController {
 		type: PartyWithMembersDto,
 	})
 	@ApiBadRequestResponse({
-		description: '잘못된 요청 데이터입니다.',
-		schema: {
-			example: {
-				success: false,
-				statusCode: 400,
-				errorCode: 'g-001',
-				message: '입력 데이터가 유효하지 않습니다.',
-				detail: '비공개 파티는 참여 코드가 필요합니다.',
-				timestamp: '2025-06-30T12:00:00.000Z',
-				path: '/parties',
+		description:
+			'잘못된 요청 데이터입니다. (e.g. 비공개 파티에 참여 코드가 없는 경우, 게임 프로필 정보가 없는 경우)',
+		content: {
+			'application/json': {
+				examples: {
+					'Validation Error': {
+						value: {
+							success: false,
+							statusCode: 400,
+							errorCode: 'g-001',
+							message: '입력 데이터가 유효하지 않습니다.',
+							detail: '비공개 파티는 참여 코드가 필요합니다.',
+							timestamp: '2025-07-03T10:00:00.000Z',
+							path: '/parties',
+						},
+					},
+				},
 			},
 		},
 	})
-	@ApiUnauthorizedResponse({
-		description: '인증이 필요합니다.',
-		schema: {
-			example: {
-				success: false,
-				statusCode: 401,
-				message: 'Unauthorized',
-				timestamp: '2025-06-30T12:00:00.000Z',
-				path: '/parties',
-			},
-		},
-	})
+	@ApiUnauthorizedResponse({ description: '인증되지 않은 사용자입니다.' })
 	@ApiNotFoundResponse({
-		description: '존재하지 않는 게임입니다.',
-		schema: {
-			example: {
-				success: false,
-				statusCode: 404,
-				errorCode: 'gm-001',
-				message: '게임을 찾을 수 없습니다.',
-				detail: '존재하지 않는 게임입니다.',
-				timestamp: '2025-06-30T12:00:00.000Z',
-				path: '/parties',
+		description: '존재하지 않는 리소스입니다. (e.g. 게임, 사용자, 게임 프로필)',
+		content: {
+			'application/json': {
+				examples: {
+					'Game Not Found': {
+						value: {
+							success: false,
+							statusCode: 404,
+							errorCode: 'gm-001',
+							message: '게임을 찾을 수 없습니다.',
+							detail: '존재하지 않는 게임입니다.',
+							timestamp: '2025-07-03T10:00:00.000Z',
+							path: '/parties',
+						},
+					},
+					'User Not Found': {
+						value: {
+							success: false,
+							statusCode: 404,
+							errorCode: 'a-001',
+							message: '사용자를 찾을 수 없습니다.',
+							detail: '존재하지 않는 사용자입니다.',
+							timestamp: '2025-07-03T10:00:00.000Z',
+							path: '/parties',
+						},
+					},
+				},
 			},
 		},
 	})
@@ -93,29 +108,20 @@ export class PartiesController {
 	@Get(':id')
 	@ApiOperation({ summary: '특정 파티 조회' })
 	@ApiOkResponse({ description: '파티 + 멤버 정보를 반환합니다.', type: PartyWithMembersDto })
-	@ApiUnauthorizedResponse({
-		description: '인증이 필요합니다.',
-		schema: {
-			example: {
-				success: false,
-				statusCode: 401,
-				message: 'Unauthorized',
-				timestamp: '2025-06-30T12:00:00.000Z',
-				path: '/parties/1',
-			},
-		},
-	})
+	@ApiUnauthorizedResponse({ description: '인증되지 않은 사용자입니다.' })
 	@ApiNotFoundResponse({
 		description: '파티를 찾을 수 없습니다.',
-		schema: {
-			example: {
-				success: false,
-				statusCode: 404,
-				errorCode: 'p-001',
-				message: '파티를 찾을 수 없습니다.',
-				detail: '존재하지 않는 파티입니다.',
-				timestamp: '2025-06-30T12:00:00.000Z',
-				path: '/parties/1',
+		content: {
+			'application/json': {
+				example: {
+					success: false,
+					statusCode: 404,
+					errorCode: 'p-001',
+					message: '파티를 찾을 수 없습니다.',
+					detail: '존재하지 않는 파티입니다.',
+					timestamp: '2025-07-03T10:00:00.000Z',
+					path: '/parties/999',
+				},
 			},
 		},
 	})
@@ -131,44 +137,65 @@ export class PartiesController {
 	})
 	@ApiBadRequestResponse({
 		description: '잘못된 요청 데이터입니다.',
-		schema: {
-			example: {
-				success: false,
-				statusCode: 400,
-				errorCode: 'g-001',
-				message: '입력 데이터가 유효하지 않습니다.',
-				detail: 'profileId 또는 gameUsername 중 하나만 입력해야 합니다.',
-				timestamp: '2025-07-01T12:00:00.000Z',
-				path: '/parties/1',
+		content: {
+			'application/json': {
+				example: {
+					success: false,
+					statusCode: 400,
+					errorCode: 'g-001',
+					message: '입력 데이터가 유효하지 않습니다.',
+					detail: '비공개 파티는 참여 코드가 필요합니다.',
+					timestamp: '2025-07-03T10:00:00.000Z',
+					path: '/parties/1',
+				},
 			},
 		},
 	})
-	@ApiUnauthorizedResponse({ description: '인증이 필요합니다.' })
+	@ApiUnauthorizedResponse({ description: '인증되지 않은 사용자입니다.' })
 	@ApiForbiddenResponse({
 		description: '권한이 없습니다.',
-		schema: {
-			example: {
-				success: false,
-				statusCode: 403,
-				errorCode: 'g-004',
-				message: '요청을 수행할 권한이 없습니다.',
-				detail: '파티를 수정할 권한이 없습니다.',
-				timestamp: '2025-07-01T12:00:00.000Z',
-				path: '/parties/1',
+		content: {
+			'application/json': {
+				example: {
+					success: false,
+					statusCode: 403,
+					errorCode: 'g-004',
+					message: '요청을 수행할 권한이 없습니다.',
+					detail: '파티를 수정할 권한이 없습니다.',
+					timestamp: '2025-07-03T10:00:00.000Z',
+					path: '/parties/1',
+				},
 			},
 		},
 	})
 	@ApiNotFoundResponse({
 		description: '파티 또는 게임 프로필을 찾을 수 없습니다.',
-		schema: {
-			example: {
-				success: false,
-				statusCode: 404,
-				errorCode: 'p-001',
-				message: '파티를 찾을 수 없습니다.',
-				detail: '존재하지 않는 파티입니다.',
-				timestamp: '2025-07-01T12:00:00.000Z',
-				path: '/parties/1',
+		content: {
+			'application/json': {
+				examples: {
+					'Party Not Found': {
+						value: {
+							success: false,
+							statusCode: 404,
+							errorCode: 'p-001',
+							message: '파티를 찾을 수 없습니다.',
+							detail: '존재하지 않는 파티입니다.',
+							timestamp: '2025-07-03T10:00:00.000Z',
+							path: '/parties/1',
+						},
+					},
+					'Profile Not Found': {
+						value: {
+							success: false,
+							statusCode: 404,
+							errorCode: 'ugp-001',
+							message: '사용자 게임 프로필을 찾을 수 없습니다.',
+							detail: '선택한 게임 프로필이 유효하지 않습니다.',
+							timestamp: '2025-07-03T10:00:00.000Z',
+							path: '/parties/1',
+						},
+					},
+				},
 			},
 		},
 	})
@@ -185,6 +212,40 @@ export class PartiesController {
 	@ApiOkResponse({
 		description: '파티가 성공적으로 삭제되었습니다.',
 		schema: { example: { message: '파티가 성공적으로 삭제되었습니다.' } },
+	})
+	@HttpCode(HttpStatus.OK) // 성공 시 200 OK
+	@ApiUnauthorizedResponse({ description: '인증되지 않은 사용자입니다.' })
+	@ApiForbiddenResponse({
+		description: '파티 생성자만 삭제할 수 있습니다.',
+		content: {
+			'application/json': {
+				example: {
+					success: false,
+					statusCode: 403,
+					errorCode: 'p-010',
+					message: '파티 생성자만 수행할 수 있는 작업입니다.',
+					detail: '파티 생성자 권한이 필요합니다.',
+					timestamp: '2025-07-03T10:00:00.000Z',
+					path: '/parties/1',
+				},
+			},
+		},
+	})
+	@ApiNotFoundResponse({
+		description: '파티를 찾을 수 없습니다.',
+		content: {
+			'application/json': {
+				example: {
+					success: false,
+					statusCode: 404,
+					errorCode: 'p-001',
+					message: '파티를 찾을 수 없습니다.',
+					detail: '존재하지 않는 파티입니다.',
+					timestamp: '2025-07-03T10:00:00.000Z',
+					path: '/parties/1',
+				},
+			},
+		},
 	})
 	async deleteParty(
 		@Param('id', ParseIntPipe) id: number,
@@ -256,55 +317,50 @@ export class PartiesController {
 	})
 	@ApiBadRequestResponse({
 		description: '이미 완료된 파티입니다.',
-		schema: {
-			example: {
-				success: false,
-				statusCode: 400,
-				errorCode: 'p-009',
-				message: '이미 완료된 파티입니다.',
-				detail: '완료된 파티는 더 이상 수정할 수 없습니다.',
-				timestamp: '2025-06-30T12:00:00.000Z',
-				path: '/parties/1/complete',
+		content: {
+			'application/json': {
+				example: {
+					success: false,
+					statusCode: 400,
+					errorCode: 'p-009',
+					message: '이미 완료된 파티입니다.',
+					detail: '완료된 파티의 상태는 변경할 수 없습니다.',
+					timestamp: '2025-07-03T10:00:00.000Z',
+					path: '/parties/1/complete',
+				},
 			},
 		},
 	})
-	@ApiUnauthorizedResponse({
-		description: '인증이 필요합니다.',
-		schema: {
-			example: {
-				success: false,
-				statusCode: 401,
-				message: 'Unauthorized',
-				timestamp: '2025-06-30T12:00:00.000Z',
-				path: '/parties/1/complete',
-			},
-		},
-	})
+	@ApiUnauthorizedResponse({ description: '인증되지 않은 사용자입니다.' })
 	@ApiForbiddenResponse({
 		description: '파티 생성자만 완료 처리할 수 있습니다.',
-		schema: {
-			example: {
-				success: false,
-				statusCode: 403,
-				errorCode: 'p-010',
-				message: '파티 생성자만 수행할 수 있는 작업입니다.',
-				detail: '파티 생성자 권한이 필요합니다.',
-				timestamp: '2025-06-30T12:00:00.000Z',
-				path: '/parties/1/complete',
+		content: {
+			'application/json': {
+				example: {
+					success: false,
+					statusCode: 403,
+					errorCode: 'p-010',
+					message: '파티 생성자만 수행할 수 있는 작업입니다.',
+					detail: '파티 생성자 권한이 필요합니다.',
+					timestamp: '2025-07-03T10:00:00.000Z',
+					path: '/parties/1/complete',
+				},
 			},
 		},
 	})
 	@ApiNotFoundResponse({
 		description: '파티를 찾을 수 없습니다.',
-		schema: {
-			example: {
-				success: false,
-				statusCode: 404,
-				errorCode: 'p-001',
-				message: '파티를 찾을 수 없습니다.',
-				detail: '존재하지 않는 파티입니다.',
-				timestamp: '2025-06-30T12:00:00.000Z',
-				path: '/parties/1/complete',
+		content: {
+			'application/json': {
+				example: {
+					success: false,
+					statusCode: 404,
+					errorCode: 'p-001',
+					message: '파티를 찾을 수 없습니다.',
+					detail: '존재하지 않는 파티입니다.',
+					timestamp: '2025-07-03T10:00:00.000Z',
+					path: '/parties/1/complete',
+				},
 			},
 		},
 	})

--- a/src/parties/controllers/party-members.controller.ts
+++ b/src/parties/controllers/party-members.controller.ts
@@ -27,7 +27,7 @@ import { MemberListResponseDto } from '../dto/response.dto';
 import { AppException } from 'src/common/exceptions/app.exception';
 import { ErrorCode } from 'src/common/constants/error-codes';
 
-@ApiTags('PartyMembers')
+@ApiTags('partyMembers')
 @Controller('parties/:partyId/members')
 export class PartyMembersController {
 	constructor(private readonly partyMembersService: PartyMembersService) {}

--- a/src/parties/controllers/party-members.controller.ts
+++ b/src/parties/controllers/party-members.controller.ts
@@ -124,6 +124,7 @@ export class PartyMembersController {
 
 	@Get()
 	@ApiBearerAuth()
+	@UseGuards(JwtAuthGuard)
 	@ApiOperation({ summary: '파티 멤버 목록 조회' })
 	@ApiOkResponse({ description: '파티 멤버 목록을 반환합니다.' })
 	@ApiUnauthorizedResponse({
@@ -148,6 +149,8 @@ export class PartyMembersController {
 	}
 
 	@Delete('/:userId')
+	@ApiBearerAuth()
+	@UseGuards(JwtAuthGuard)
 	@ApiOperation({ summary: '파티원 강퇴 (파티장만)' })
 	@ApiOkResponse({
 		description: '파티원을 강퇴했습니다.',
@@ -157,23 +160,38 @@ export class PartyMembersController {
 		description: '자기 자신을 강퇴할 수 없습니다.',
 		schema: {
 			example: {
+				success: false,
 				statusCode: 400,
+				errorCode: 'p-008',
 				message: '자기 자신을 강퇴할 수 없습니다.',
-				error: 'Bad Request',
+				detail: '파티장은 자기 자신을 강퇴할 수 없습니다.',
+				timestamp: '2025-06-30T12:00:00.000Z',
+				path: '/parties/1/members/1',
 			},
 		},
 	})
 	@ApiUnauthorizedResponse({
 		description: '인증이 필요합니다.',
-		schema: { example: { statusCode: 401, message: 'Unauthorized' } },
+		schema: {
+			example: {
+				success: false,
+				statusCode: 401,
+				errorCode: 'u-001',
+				message: '인증이 필요합니다.',
+			},
+		},
 	})
 	@ApiForbiddenResponse({
 		description: '파티장만 강퇴할 수 있습니다.',
 		schema: {
 			example: {
+				success: false,
 				statusCode: 403,
-				message: '파티장만 강퇴할 수 있습니다.',
-				error: 'Forbidden',
+				errorCode: 'p-002',
+				message: '파티장만 이 작업을 수행할 수 있습니다.',
+				detail: '오직 파티장만 멤버를 강퇴할 수 있습니다.',
+				timestamp: '2025-06-30T12:00:00.000Z',
+				path: '/parties/1/members/2',
 			},
 		},
 	})
@@ -181,9 +199,13 @@ export class PartyMembersController {
 		description: '파티나 멤버를 찾을 수 없습니다.',
 		schema: {
 			example: {
+				success: false,
 				statusCode: 404,
+				errorCode: 'p-007',
 				message: '해당 멤버를 찾을 수 없습니다.',
-				error: 'Not Found',
+				detail: '파티에서 ID가 2인 멤버를 찾을 수 없습니다.',
+				timestamp: '2025-06-30T12:00:00.000Z',
+				path: '/parties/1/members/2',
 			},
 		},
 	})
@@ -197,6 +219,8 @@ export class PartyMembersController {
 	}
 
 	@Put('/leader/:userId')
+	@ApiBearerAuth()
+	@UseGuards(JwtAuthGuard)
 	@ApiOperation({ summary: '파티장 권한 이양 (파티장만)' })
 	@ApiOkResponse({
 		description: '파티장을 변경했습니다.',
@@ -206,23 +230,38 @@ export class PartyMembersController {
 		description: '자기 자신에게 권한을 이양할 수 없습니다.',
 		schema: {
 			example: {
+				success: false,
 				statusCode: 400,
+				errorCode: 'p-010',
 				message: '자기 자신에게 권한을 이양할 수 없습니다.',
-				error: 'Bad Request',
+				detail: '파티장은 자기 자신에게 리더 권한을 넘길 수 없습니다.',
+				timestamp: '2025-06-30T12:00:00.000Z',
+				path: '/parties/1/leader/1',
 			},
 		},
 	})
 	@ApiUnauthorizedResponse({
 		description: '인증이 필요합니다.',
-		schema: { example: { statusCode: 401, message: 'Unauthorized' } },
+		schema: {
+			example: {
+				success: false,
+				statusCode: 401,
+				errorCode: 'u-001',
+				message: '인증이 필요합니다.',
+			},
+		},
 	})
 	@ApiForbiddenResponse({
 		description: '파티장만 권한을 이양할 수 있습니다.',
 		schema: {
 			example: {
+				success: false,
 				statusCode: 403,
-				message: '파티장만 권한을 이양할 수 있습니다.',
-				error: 'Forbidden',
+				errorCode: 'p-002',
+				message: '파티장만 이 작업을 수행할 수 있습니다.',
+				detail: '오직 파티장만 리더를 변경할 수 있습니다.',
+				timestamp: '2025-06-30T12:00:00.000Z',
+				path: '/parties/1/leader/2',
 			},
 		},
 	})
@@ -230,9 +269,13 @@ export class PartyMembersController {
 		description: '파티나 멤버를 찾을 수 없습니다.',
 		schema: {
 			example: {
+				success: false,
 				statusCode: 404,
+				errorCode: 'p-007',
 				message: '해당 멤버를 찾을 수 없습니다.',
-				error: 'Not Found',
+				detail: '파티에서 ID가 2인 멤버를 찾을 수 없습니다.',
+				timestamp: '2025-06-30T12:00:00.000Z',
+				path: '/parties/1/leader/2',
 			},
 		},
 	})

--- a/src/parties/controllers/party-members.controller.ts
+++ b/src/parties/controllers/party-members.controller.ts
@@ -92,7 +92,7 @@ export class PartyMembersController {
 		return { message: `${username}님이 파티에 참가했습니다.` };
 	}
 
-	@Delete('/me')
+	@Delete()
 	@ApiBearerAuth()
 	@UseGuards(JwtAuthGuard)
 	@ApiOperation({ summary: '파티 탈퇴' })
@@ -111,7 +111,7 @@ export class PartyMembersController {
 					message: '파티장은 파티를 떠날 수 없습니다.',
 					detail: '파티장을 다른 멤버에게 위임한 후 떠나주세요.',
 					timestamp: '2025-07-03T10:00:00.000Z',
-					path: '/parties/1/members/me',
+					path: '/parties/1/members',
 				},
 			},
 		},
@@ -127,7 +127,7 @@ export class PartyMembersController {
 					message: '인증되지 않은 사용자입니다.',
 					detail: '유효한 인증 토큰이 제공되지 않았습니다.',
 					timestamp: '2025-07-03T10:00:00.000Z',
-					path: '/parties/1/members/me',
+					path: '/parties/1/members',
 				},
 			},
 		},
@@ -143,7 +143,7 @@ export class PartyMembersController {
 					message: '파티 멤버를 찾을 수 없습니다.',
 					detail: '해당 사용자는 이 파티의 멤버가 아닙니다.',
 					timestamp: '2025-07-03T10:00:00.000Z',
-					path: '/parties/1/members/me',
+					path: '/parties/1/members',
 				},
 			},
 		},

--- a/src/parties/controllers/party-members.controller.ts
+++ b/src/parties/controllers/party-members.controller.ts
@@ -55,17 +55,31 @@ export class PartyMembersController {
 		},
 	})
 	@ApiUnauthorizedResponse({
-		description: '인증이 필요합니다.',
-		schema: { example: { statusCode: 401, message: 'Unauthorized' } },
+		description: '인증되지 않은 사용자입니다.',
+		content: {
+			'application/json': {
+				example: {
+					success: false,
+					statusCode: 401,
+					errorCode: 'a-002',
+					message: '인증되지 않은 사용자입니다.',
+					detail: '유효한 인증 토큰이 제공되지 않았습니다.',
+					timestamp: '2025-07-03T10:00:00.000Z',
+					path: '/parties/1/members',
+				},
+			},
+		},
 	})
 	@ApiNotFoundResponse({
 		description: '파티를 찾을 수 없습니다.',
-		schema: {
-			example: {
-				success: false,
-				statusCode: 404,
-				errorCode: 'p-001',
-				message: '파티를 찾을 수 없습니다.',
+		content: {
+			'application/json': {
+				example: {
+					success: false,
+					statusCode: 404,
+					errorCode: 'p-001',
+					message: '파티를 찾을 수 없습니다.',
+				},
 			},
 		},
 	})
@@ -86,27 +100,51 @@ export class PartyMembersController {
 		description: '파티에서 탈퇴했습니다.',
 		schema: { example: { message: 'user1님이 파티에서 탈퇴했습니다.' } },
 	})
-	@ApiBadRequestResponse({
+	@ApiForbiddenResponse({
 		description: '파티장은 탈퇴할 수 없습니다.',
-		schema: {
-			example: {
-				statusCode: 400,
-				message: '파티장은 탈퇴할 수 없습니다.',
-				error: 'Bad Request',
+		content: {
+			'application/json': {
+				example: {
+					success: false,
+					statusCode: 403,
+					errorCode: 'p-005',
+					message: '파티장은 파티를 떠날 수 없습니다.',
+					detail: '파티장을 다른 멤버에게 위임한 후 떠나주세요.',
+					timestamp: '2025-07-03T10:00:00.000Z',
+					path: '/parties/1/members/me',
+				},
 			},
 		},
 	})
 	@ApiUnauthorizedResponse({
-		description: '인증이 필요합니다.',
-		schema: { example: { statusCode: 401, message: 'Unauthorized' } },
+		description: '인증되지 않은 사용자입니다.',
+		content: {
+			'application/json': {
+				example: {
+					success: false,
+					statusCode: 401,
+					errorCode: 'a-002',
+					message: '인증되지 않은 사용자입니다.',
+					detail: '유효한 인증 토큰이 제공되지 않았습니다.',
+					timestamp: '2025-07-03T10:00:00.000Z',
+					path: '/parties/1/members/me',
+				},
+			},
+		},
 	})
 	@ApiNotFoundResponse({
-		description: '파티에 참가하지 않았습니다.',
-		schema: {
-			example: {
-				statusCode: 404,
-				message: '파티에 참가하지 않았습니다.',
-				error: 'Not Found',
+		description: '파티 멤버를 찾을 수 없습니다. (파티에 참가하지 않은 경우)',
+		content: {
+			'application/json': {
+				example: {
+					success: false,
+					statusCode: 404,
+					errorCode: 'p-006',
+					message: '파티 멤버를 찾을 수 없습니다.',
+					detail: '해당 사용자는 이 파티의 멤버가 아닙니다.',
+					timestamp: '2025-07-03T10:00:00.000Z',
+					path: '/parties/1/members/me',
+				},
 			},
 		},
 	})
@@ -126,19 +164,33 @@ export class PartyMembersController {
 	@ApiBearerAuth()
 	@UseGuards(JwtAuthGuard)
 	@ApiOperation({ summary: '파티 멤버 목록 조회' })
-	@ApiOkResponse({ description: '파티 멤버 목록을 반환합니다.' })
+	@ApiOkResponse({ description: '파티 멤버 목록을 반환합니다.', type: MemberListResponseDto })
 	@ApiUnauthorizedResponse({
-		description: '인증이 필요합니다.',
-		schema: { example: { statusCode: 401, message: 'Unauthorized' } },
+		description: '인증되지 않은 사용자입니다.',
+		content: {
+			'application/json': {
+				example: {
+					success: false,
+					statusCode: 401,
+					errorCode: 'a-002',
+					message: '인증되지 않은 사용자입니다.',
+					detail: '유효한 인증 토큰이 제공되지 않았습니다.',
+					timestamp: '2025-07-03T10:00:00.000Z',
+					path: '/parties/1/members',
+				},
+			},
+		},
 	})
 	@ApiNotFoundResponse({
 		description: '파티를 찾을 수 없습니다.',
-		schema: {
-			example: {
-				success: false,
-				statusCode: 404,
-				errorCode: 'p-001',
-				message: '파티를 찾을 수 없습니다.',
+		content: {
+			'application/json': {
+				example: {
+					success: false,
+					statusCode: 404,
+					errorCode: 'p-001',
+					message: '파티를 찾을 수 없습니다.',
+				},
 			},
 		},
 	})
@@ -171,41 +223,63 @@ export class PartyMembersController {
 		},
 	})
 	@ApiUnauthorizedResponse({
-		description: '인증이 필요합니다.',
-		schema: {
-			example: {
-				success: false,
-				statusCode: 401,
-				errorCode: 'u-001',
-				message: '인증이 필요합니다.',
+		description: '인증되지 않은 사용자입니다.',
+		content: {
+			'application/json': {
+				example: {
+					success: false,
+					statusCode: 401,
+					errorCode: 'a-002',
+					message: '인증되지 않은 사용자입니다.',
+					detail: '유효한 인증 토큰이 제공되지 않았습니다.',
+					timestamp: '2025-07-03T10:00:00.000Z',
+					path: '/parties/1/members/2',
+				},
 			},
 		},
 	})
 	@ApiForbiddenResponse({
 		description: '파티장만 강퇴할 수 있습니다.',
-		schema: {
-			example: {
-				success: false,
-				statusCode: 403,
-				errorCode: 'p-002',
-				message: '파티장만 이 작업을 수행할 수 있습니다.',
-				detail: '오직 파티장만 멤버를 강퇴할 수 있습니다.',
-				timestamp: '2025-06-30T12:00:00.000Z',
-				path: '/parties/1/members/2',
+		content: {
+			'application/json': {
+				example: {
+					success: false,
+					statusCode: 403,
+					errorCode: 'p-002',
+					message: '파티장만 이 작업을 수행할 수 있습니다.',
+					detail: '오직 파티장만 멤버를 강퇴할 수 있습니다.',
+					timestamp: '2025-06-30T12:00:00.000Z',
+					path: '/parties/1/members/2',
+				},
 			},
 		},
 	})
 	@ApiNotFoundResponse({
 		description: '파티나 멤버를 찾을 수 없습니다.',
-		schema: {
-			example: {
-				success: false,
-				statusCode: 404,
-				errorCode: 'p-007',
-				message: '해당 멤버를 찾을 수 없습니다.',
-				detail: '파티에서 ID가 2인 멤버를 찾을 수 없습니다.',
-				timestamp: '2025-06-30T12:00:00.000Z',
-				path: '/parties/1/members/2',
+		content: {
+			'application/json': {
+				examples: {
+					'파티 없음': {
+						value: {
+							success: false,
+							statusCode: 404,
+							errorCode: 'p-001',
+							message: '파티를 찾을 수 없습니다.',
+							timestamp: '2025-07-03T10:00:00.000Z',
+							path: '/parties/999/members/2',
+						},
+					},
+					'멤버 없음': {
+						value: {
+							success: false,
+							statusCode: 404,
+							errorCode: 'p-009',
+							message: '해당 유저는 파티 멤버가 아닙니다.',
+							timestamp: '2025-07-03T10:00:00.000Z',
+							path: '/parties/1/members/999',
+						},
+					},
+				},
 			},
 		},
 	})
@@ -241,41 +315,63 @@ export class PartyMembersController {
 		},
 	})
 	@ApiUnauthorizedResponse({
-		description: '인증이 필요합니다.',
-		schema: {
-			example: {
-				success: false,
-				statusCode: 401,
-				errorCode: 'u-001',
-				message: '인증이 필요합니다.',
+		description: '인증되지 않은 사용자입니다.',
+		content: {
+			'application/json': {
+				example: {
+					success: false,
+					statusCode: 401,
+					errorCode: 'a-002',
+					message: '인증되지 않은 사용자입니다.',
+					detail: '유효한 인증 토큰이 제공되지 않았습니다.',
+					timestamp: '2025-07-03T10:00:00.000Z',
+					path: '/parties/1/members/leader',
+				},
 			},
 		},
 	})
 	@ApiForbiddenResponse({
-		description: '파티장만 권한을 이양할 수 있습니다.',
-		schema: {
-			example: {
-				success: false,
-				statusCode: 403,
-				errorCode: 'p-002',
-				message: '파티장만 이 작업을 수행할 수 있습니다.',
-				detail: '오직 파티장만 리더를 변경할 수 있습니다.',
-				timestamp: '2025-06-30T12:00:00.000Z',
-				path: '/parties/1/leader/2',
+		description: '파티장만 위임할 수 있습니다.',
+		content: {
+			'application/json': {
+				example: {
+					success: false,
+					statusCode: 403,
+					errorCode: 'p-002',
+					message: '파티장만 이 작업을 수행할 수 있습니다.',
+					detail: '오직 파티장만 리더를 변경할 수 있습니다.',
+					timestamp: '2025-06-30T12:00:00.000Z',
+					path: '/parties/1/members/leader',
+				},
 			},
 		},
 	})
 	@ApiNotFoundResponse({
 		description: '파티나 멤버를 찾을 수 없습니다.',
-		schema: {
-			example: {
-				success: false,
-				statusCode: 404,
-				errorCode: 'p-007',
-				message: '해당 멤버를 찾을 수 없습니다.',
-				detail: '파티에서 ID가 2인 멤버를 찾을 수 없습니다.',
-				timestamp: '2025-06-30T12:00:00.000Z',
-				path: '/parties/1/leader/2',
+		content: {
+			'application/json': {
+				examples: {
+					'파티 없음': {
+						value: {
+							success: false,
+							statusCode: 404,
+							errorCode: 'p-001',
+							message: '파티를 찾을 수 없습니다.',
+							timestamp: '2025-07-03T10:00:00.000Z',
+							path: '/parties/999/members/leader',
+						},
+					},
+					'멤버 없음': {
+						value: {
+							success: false,
+							statusCode: 404,
+							errorCode: 'p-009',
+							message: '해당 유저는 파티 멤버가 아닙니다.',
+							timestamp: '2025-07-03T10:00:00.000Z',
+							path: '/parties/1/members/leader',
+						},
+					},
+				},
 			},
 		},
 	})

--- a/src/parties/dto/party-with-members.dto.ts
+++ b/src/parties/dto/party-with-members.dto.ts
@@ -18,6 +18,9 @@ export class PartyMemberSummaryDto {
 
 	@ApiProperty({ required: false })
 	leftAt?: Date;
+
+	@ApiProperty({ example: 'pro_gamer123', description: '게임 내 닉네임' })
+	gameUsername: string;
 }
 
 // 파티에서만 사용하는 생성자 정보 DTO (password 등 민감 정보 제외)

--- a/src/parties/dto/response.dto.ts
+++ b/src/parties/dto/response.dto.ts
@@ -62,11 +62,6 @@ export class PartyListItemDto {
 	currentMemberCount: number;
 }
 
-export class UserGameProfileDto {
-	@ApiProperty({ example: 'player123' })
-	gameUsername: string;
-}
-
 export class PartyMemberDetailDto {
 	@ApiProperty({ example: 1 })
 	id: number; // PartyMembers.id
@@ -83,8 +78,8 @@ export class PartyMemberDetailDto {
 	@ApiProperty({ example: '2025-06-27T09:00:00+09:00' })
 	joinedAt: string;
 
-	@ApiProperty({ type: () => UserGameProfileDto })
-	userGameProfile: UserGameProfileDto;
+	@ApiProperty({ example: 'player123', description: '게임 내 닉네임' })
+	gameUsername: string;
 }
 
 // 기본 파티 정보 DTO (재사용 가능)

--- a/src/parties/services/parties.service.ts
+++ b/src/parties/services/parties.service.ts
@@ -42,7 +42,7 @@ export class PartiesService {
 			const creator = await queryRunner.manager.findOneBy(User, { id: creatorId });
 			if (!creator) throw new AppException(ErrorCode.USER_NOT_FOUND);
 
-                        let userGameProfile: UserGameProfile; // 타입을 명확히 지정
+			let userGameProfile: { id: number }; // 타입을 명확히 지정
 			if (dto.profileId) {
 				const profile = await this.userGameProfilesService.getUserGameProfileById(
 					dto.profileId,
@@ -116,7 +116,7 @@ export class PartiesService {
 			// 리더의 게임 프로필을 명확히 조회하여 맵에 포함
 			const leaderUserId = creatorId;
 			const leaderGameId = dto.gameId;
-                        const leaderProfile = userGameProfile;
+			const leaderProfile = userGameProfile as { gameUsername: string; id: number }; // 타입 단언 추가
 			const userGameProfilesMap = new Map<string, string>();
 			if (leaderProfile && leaderProfile.gameUsername) {
 				userGameProfilesMap.set(

--- a/src/parties/services/parties.service.ts
+++ b/src/parties/services/parties.service.ts
@@ -284,7 +284,17 @@ export class PartiesService {
 		});
 	}
 
-	async findUserParties(userId: number): Promise<PartyListItemDto[]> {
+	async findUserParties(
+		userId: number,
+		query: {
+			isCompleted?: boolean;
+			isPrivate?: boolean;
+			page?: number;
+			limit?: number;
+		},
+	): Promise<PartyListItemDto[]> {
+		const { isCompleted, isPrivate, page = 1, limit = 20 } = query;
+
 		const userPartyMemberships = await this.partyMemberRepository.find({
 			where: { userId },
 			select: ['partyId'],
@@ -296,10 +306,16 @@ export class PartiesService {
 
 		const partyIds = userPartyMemberships.map((m) => m.partyId);
 
+		const where: FindOptionsWhere<Party> = { id: In(partyIds) };
+		if (isCompleted !== undefined) where.isCompleted = isCompleted;
+		if (isPrivate !== undefined) where.isPrivate = isPrivate;
+
 		const parties = await this.partyRepository.find({
-			where: { id: In(partyIds) },
+			where,
 			relations: ['game', 'members', 'members.user'],
 			order: { createdAt: 'DESC' },
+			skip: (page - 1) * limit,
+			take: limit,
 		});
 
 		const leaderInfos = parties

--- a/src/parties/services/parties.service.ts
+++ b/src/parties/services/parties.service.ts
@@ -94,9 +94,9 @@ export class PartiesService {
 				);
 			}
 
-			const userGameProfilesMap = new Map<string, string>();
-			if (userGameProfile?.gameUsername) {
-				userGameProfilesMap.set(`${creatorId}-${dto.gameId}`, userGameProfile.gameUsername);
+			const userGameProfilesMap = new Map<number, string>();
+			if (userGameProfile?.id && userGameProfile?.gameUsername) {
+				userGameProfilesMap.set(userGameProfile.id, userGameProfile.gameUsername);
 			}
 
 			return this.toPartyWithMembersDto(createdParty, userGameProfilesMap);
@@ -110,19 +110,18 @@ export class PartiesService {
 		});
 		if (!party) throw new AppException(ErrorCode.PARTY_NOT_FOUND);
 
-		const memberInfos = (party.members || [])
-			.filter((m) => m.userId && party.gameId)
-			.map((m) => ({ userId: m.userId, gameId: party.gameId }));
-
-		const userGameProfilesMap =
-			await this.userGameProfilesService.getGameProfilesForUsers(memberInfos);
+		const profileIds = (party.members || [])
+			.map((m) => m.userGameProfileId)
+			.filter((id) => id) as number[];
+		const profiles = await this.userGameProfilesService.getProfilesByIds(profileIds);
+		const userGameProfilesMap = new Map(profiles.map((p) => [p.id, p.gameUsername]));
 
 		return this.toPartyWithMembersDto(party, userGameProfilesMap);
 	}
 
 	toPartyWithMembersDto(
 		party: Party,
-		userGameProfilesMap?: Map<string, string>,
+		userGameProfilesMap?: Map<number, string>,
 	): PartyWithMembersDto {
 		const { creator, members, ...partyDetails } = party;
 		return {
@@ -142,7 +141,9 @@ export class PartiesService {
 				isLeader: m.isLeader,
 				joinedAt: m.joinedAt,
 				leftAt: m.leftAt,
-				gameUsername: userGameProfilesMap?.get(`${m.userId}-${party.gameId}`) ?? '',
+				gameUsername: m.userGameProfileId
+					? (userGameProfilesMap?.get(m.userGameProfileId) ?? '')
+					: '',
 			})),
 		};
 	}
@@ -199,12 +200,11 @@ export class PartiesService {
 
 			const updatedPartyEntity = await manager.save(party);
 
-			const memberInfos = (updatedPartyEntity.members || [])
-				.filter((m) => m.userId && updatedPartyEntity.gameId)
-				.map((m) => ({ userId: m.userId, gameId: updatedPartyEntity.gameId }));
-
-			const userGameProfilesMap =
-				await this.userGameProfilesService.getGameProfilesForUsers(memberInfos);
+			const profileIds = (updatedPartyEntity.members || [])
+				.map((m) => m.userGameProfileId)
+				.filter((id) => id) as number[];
+			const profiles = await this.userGameProfilesService.getProfilesByIds(profileIds);
+			const userGameProfilesMap = new Map(profiles.map((p) => [p.id, p.gameUsername]));
 
 			return this.toPartyWithMembersDto(updatedPartyEntity, userGameProfilesMap);
 		});

--- a/src/parties/services/parties.service.ts
+++ b/src/parties/services/parties.service.ts
@@ -116,7 +116,7 @@ export class PartiesService {
 			// 리더의 게임 프로필을 명확히 조회하여 맵에 포함
 			const leaderUserId = creatorId;
 			const leaderGameId = dto.gameId;
-			const leaderProfile = userGameProfile as { gameUsername: string; id: number }; // 타입 단언 추가
+                        const leaderProfile = userGameProfile;
 			const userGameProfilesMap = new Map<string, string>();
 			if (leaderProfile && leaderProfile.gameUsername) {
 				userGameProfilesMap.set(

--- a/src/parties/services/parties.service.ts
+++ b/src/parties/services/parties.service.ts
@@ -42,7 +42,7 @@ export class PartiesService {
 			const creator = await queryRunner.manager.findOneBy(User, { id: creatorId });
 			if (!creator) throw new AppException(ErrorCode.USER_NOT_FOUND);
 
-			let userGameProfile: { id: number }; // 타입을 명확히 지정
+                        let userGameProfile: UserGameProfile; // 타입을 명확히 지정
 			if (dto.profileId) {
 				const profile = await this.userGameProfilesService.getUserGameProfileById(
 					dto.profileId,

--- a/src/parties/services/parties.service.ts
+++ b/src/parties/services/parties.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { AppException } from '../../common/exceptions/app.exception';
 import { ErrorCode } from '../../common/constants/error-codes';
 import { InjectRepository } from '@nestjs/typeorm';
-import { DataSource, Repository } from 'typeorm';
+import { DataSource, FindOptionsWhere, Repository } from 'typeorm';
 import { Party } from '../entities/party.entity';
 import { Game } from '../../games/entities/game.entity';
 import { User } from '../../users/entities/user.entity';
@@ -11,6 +11,8 @@ import { CreatePartyDto } from '../dto/create-party.dto';
 import { UpdatePartyDto } from '../dto/update-party.dto';
 import { PartyWithMembersDto } from '../dto/party-with-members.dto';
 import { UserGameProfilesService } from '../../user-game-profiles/services/user-game-profiles.service';
+import { PartyListItemDto } from '../dto/response.dto';
+import { UserGameProfile } from 'src/user-game-profiles/entities/user-game-profile.entity';
 
 @Injectable()
 export class PartiesService {
@@ -18,44 +20,30 @@ export class PartiesService {
 		@InjectRepository(Party)
 		private readonly partyRepository: Repository<Party>,
 		private readonly userGameProfilesService: UserGameProfilesService,
-		@InjectRepository(Game)
-		private readonly gameRepository: Repository<Game>,
-		@InjectRepository(User)
-		private readonly userRepository: Repository<User>,
-		@InjectRepository(PartyMember)
-		private readonly partyMemberRepository: Repository<PartyMember>,
 		private readonly dataSource: DataSource,
 	) {}
 
-	/**
-	 * 파티 생성
-	 */
 	async createParty(dto: CreatePartyDto, creatorId: number): Promise<PartyWithMembersDto> {
-		const queryRunner = this.dataSource.createQueryRunner();
-		await queryRunner.connect();
-		await queryRunner.startTransaction();
-
-		try {
-			const game = await queryRunner.manager.findOneBy(Game, { id: dto.gameId });
+		return this.dataSource.transaction(async (manager) => {
+			const game = await manager.findOneBy(Game, { id: dto.gameId });
 			if (!game) throw new AppException(ErrorCode.GAME_NOT_FOUND);
 
-			const creator = await queryRunner.manager.findOneBy(User, { id: creatorId });
+			const creator = await manager.findOneBy(User, { id: creatorId });
 			if (!creator) throw new AppException(ErrorCode.USER_NOT_FOUND);
 
-			let userGameProfile: { id: number }; // 타입을 명확히 지정
+			let userGameProfile: UserGameProfile | null;
 			if (dto.profileId) {
-				const profile = await this.userGameProfilesService.getUserGameProfileById(
+				userGameProfile = await this.userGameProfilesService.getUserGameProfileById(
 					dto.profileId,
 					creatorId,
 					dto.gameId,
 				);
-				if (!profile) {
+				if (!userGameProfile) {
 					throw new AppException(
 						ErrorCode.USER_GAME_PROFILE_NOT_FOUND,
 						'선택한 게임 프로필이 존재하지 않습니다.',
 					);
 				}
-				userGameProfile = profile;
 			} else if (dto.gameUsername) {
 				userGameProfile = await this.userGameProfilesService.findOrCreateUserGameProfile(
 					creatorId,
@@ -76,36 +64,27 @@ export class PartiesService {
 				);
 			}
 
-			const party = queryRunner.manager.create(Party, {
-				title: dto.title,
-				gameId: dto.gameId,
-				creatorId: creatorId,
-				purposeTag: dto.purposeTag,
-				maxParticipants: dto.maxParticipants,
-				description: dto.description,
-				isPrivate: dto.isPrivate ?? false,
+			const party = manager.create(Party, {
+				...dto,
+				creatorId,
 				accessCode: dto.isPrivate ? dto.accessCode : undefined,
 				isCompleted: false,
 			});
-			const newParty = await queryRunner.manager.save(party);
+			const newParty = await manager.save(party);
 
-			const partyMember = queryRunner.manager.create(PartyMember, {
+			const partyMember = manager.create(PartyMember, {
 				partyId: newParty.id,
 				userId: creatorId,
 				isLeader: true,
-				userGameProfileId: userGameProfile.id, // 생성자의 게임 프로필 ID 저장
+				userGameProfileId: userGameProfile.id,
 			});
-			await queryRunner.manager.save(partyMember);
+			await manager.save(partyMember);
 
-			// 트랜잭션 내에서 생성된 파티 정보 조회 (relations 포함)
-			const createdParty = await queryRunner.manager.findOne(Party, {
+			const createdParty = await manager.findOne(Party, {
 				where: { id: newParty.id },
 				relations: ['creator', 'game', 'members', 'members.user'],
 			});
 
-			await queryRunner.commitTransaction();
-
-			// 방어적 프로그래밍: 생성된 파티가 조회되지 않는 예외 상황 대비
 			if (!createdParty) {
 				throw new AppException(
 					ErrorCode.PARTY_NOT_FOUND,
@@ -113,31 +92,14 @@ export class PartiesService {
 				);
 			}
 
-			// 리더의 게임 프로필을 명확히 조회하여 맵에 포함
-			const leaderUserId = creatorId;
-			const leaderGameId = dto.gameId;
-			const leaderProfile = userGameProfile as { gameUsername: string; id: number }; // 타입 단언 추가
 			const userGameProfilesMap = new Map<string, string>();
-			if (leaderProfile && leaderProfile.gameUsername) {
-				userGameProfilesMap.set(
-					`${leaderUserId}-${leaderGameId}`,
-					leaderProfile.gameUsername,
-				);
+			if (userGameProfile?.gameUsername) {
+				userGameProfilesMap.set(`${creatorId}-${dto.gameId}`, userGameProfile.gameUsername);
 			}
 
 			return this.toPartyWithMembersDto(createdParty, userGameProfilesMap);
-		} catch (error) {
-			await queryRunner.rollbackTransaction();
-			if (error instanceof AppException) throw error;
-			throw new AppException(ErrorCode.INTERNAL_SERVER_ERROR);
-		} finally {
-			await queryRunner.release();
-		}
+		});
 	}
-
-	/**
-	 * 파티 ID로 파티 조회 (DTO 변환)
-	 */
 
 	async findPartyById(id: number): Promise<PartyWithMembersDto> {
 		const party = await this.partyRepository.findOne({
@@ -146,7 +108,6 @@ export class PartiesService {
 		});
 		if (!party) throw new AppException(ErrorCode.PARTY_NOT_FOUND);
 
-		// 멤버별 gameUsername 일괄 조회
 		const memberInfos = (party.members || [])
 			.filter((m) => m.userId && party.gameId)
 			.map((m) => ({ userId: m.userId, gameId: party.gameId }));
@@ -157,40 +118,13 @@ export class PartiesService {
 		return this.toPartyWithMembersDto(party, userGameProfilesMap);
 	}
 
-	/**
-	 * Party 엔티티를 PartyWithMembersDto로 변환 (password 등 민감 정보 제거)
-	 */
 	toPartyWithMembersDto(
 		party: Party,
 		userGameProfilesMap?: Map<string, string>,
 	): PartyWithMembersDto {
-		const {
-			id,
-			title,
-			gameId,
-			creatorId,
-			purposeTag,
-			maxParticipants,
-			description,
-			isPrivate,
-			isCompleted,
-			createdAt,
-			updatedAt,
-			creator,
-			members,
-		} = party;
+		const { creator, members, ...partyDetails } = party;
 		return {
-			id,
-			title,
-			gameId,
-			creatorId,
-			purposeTag,
-			maxParticipants,
-			description,
-			isPrivate,
-			isCompleted,
-			createdAt,
-			updatedAt,
+			...partyDetails,
 			creator: creator
 				? {
 						id: creator.id,
@@ -206,25 +140,18 @@ export class PartiesService {
 				isLeader: m.isLeader,
 				joinedAt: m.joinedAt,
 				leftAt: m.leftAt,
-				gameUsername: userGameProfilesMap?.get(`${m.userId}-${gameId}`) ?? '',
+				gameUsername: userGameProfilesMap?.get(`${m.userId}-${party.gameId}`) ?? '',
 			})),
 		};
 	}
 
-	/**
-	 * 파티 정보 수정
-	 */
 	async updateParty(
 		partyId: number,
 		dto: UpdatePartyDto,
 		userId: number,
 	): Promise<PartyWithMembersDto> {
-		const queryRunner = this.dataSource.createQueryRunner();
-		await queryRunner.connect();
-		await queryRunner.startTransaction();
-
-		try {
-			const party = await queryRunner.manager.findOne(Party, {
+		return this.dataSource.transaction(async (manager) => {
+			const party = await manager.findOne(Party, {
 				where: { id: partyId },
 				relations: ['creator', 'game', 'members', 'members.user'],
 			});
@@ -232,12 +159,10 @@ export class PartiesService {
 			if (!party) {
 				throw new AppException(ErrorCode.PARTY_NOT_FOUND);
 			}
-
 			if (party.creatorId !== userId) {
 				throw new AppException(ErrorCode.FORBIDDEN, '파티를 수정할 권한이 없습니다.');
 			}
 
-			// 호스트 게임 프로필 업데이트 로직
 			if (dto.profileId) {
 				const profile = await this.userGameProfilesService.getUserGameProfileById(
 					dto.profileId,
@@ -251,7 +176,6 @@ export class PartiesService {
 					);
 				}
 			} else if (dto.gameUsername) {
-				// 새로운 gameUsername으로 프로필 생성 (기존 프로필은 유지)
 				await this.userGameProfilesService.findOrCreateUserGameProfile(
 					userId,
 					party.gameId,
@@ -259,10 +183,9 @@ export class PartiesService {
 				);
 			}
 
-			// 파티 정보 업데이트
 			Object.assign(party, {
 				...dto,
-				accessCode: dto.isPrivate ? dto.accessCode : undefined,
+				accessCode: dto.isPrivate === true ? dto.accessCode : undefined,
 			});
 
 			if (party.isPrivate && !party.accessCode) {
@@ -272,44 +195,20 @@ export class PartiesService {
 				);
 			}
 
-			await queryRunner.manager.save(party);
+			const updatedPartyEntity = await manager.save(party);
 
-			const updatedParty = await queryRunner.manager.findOne(Party, {
-				where: { id: party.id },
-				relations: ['creator', 'game', 'members', 'members.user'],
-			});
-
-			await queryRunner.commitTransaction();
-
-			if (!updatedParty) {
-				throw new AppException(
-					ErrorCode.PARTY_NOT_FOUND,
-					'파티 업데이트 후 조회에 실패했습니다.',
-				);
-			}
-
-			const memberInfos = (updatedParty.members || [])
-				.filter((m) => m.userId && updatedParty.gameId)
-				.map((m) => ({ userId: m.userId, gameId: updatedParty.gameId }));
+			const memberInfos = (updatedPartyEntity.members || [])
+				.filter((m) => m.userId && updatedPartyEntity.gameId)
+				.map((m) => ({ userId: m.userId, gameId: updatedPartyEntity.gameId }));
 
 			const userGameProfilesMap =
 				await this.userGameProfilesService.getGameProfilesForUsers(memberInfos);
 
-			return this.toPartyWithMembersDto(updatedParty, userGameProfilesMap);
-		} catch (error) {
-			await queryRunner.rollbackTransaction();
-			if (error instanceof AppException) throw error;
-			throw new AppException(ErrorCode.INTERNAL_SERVER_ERROR);
-		} finally {
-			await queryRunner.release();
-		}
+			return this.toPartyWithMembersDto(updatedPartyEntity, userGameProfilesMap);
+		});
 	}
 
-	/**
-	 * 파티 삭제
-	 */
 	async deleteParty(partyId: number, userId: number): Promise<void> {
-		// Party 엔티티로 조회해야 remove가 정상 동작
 		const party = await this.partyRepository.findOne({ where: { id: partyId } });
 		if (!party) throw new AppException(ErrorCode.PARTY_NOT_FOUND);
 		if (party.creatorId !== userId) {
@@ -324,23 +223,22 @@ export class PartiesService {
 		isPrivate?: boolean;
 		page?: number;
 		limit?: number;
-	}): Promise<import('../dto/response.dto').PartyListItemDto[]> {
-		// relations: game, members, members.user, members.userGameProfile
-		const qb = this.partyRepository
-			.createQueryBuilder('party')
-			.leftJoinAndSelect('party.game', 'game')
-			.leftJoinAndSelect('party.members', 'members')
-			.leftJoinAndSelect('members.user', 'user');
-		if (query.gameId) qb.andWhere('party.gameId = :gameId', { gameId: query.gameId });
-		if (query.isCompleted !== undefined)
-			qb.andWhere('party.isCompleted = :isCompleted', { isCompleted: query.isCompleted });
-		if (query.isPrivate !== undefined)
-			qb.andWhere('party.isPrivate = :isPrivate', { isPrivate: query.isPrivate });
-		qb.orderBy('party.createdAt', 'DESC');
-		qb.skip(((query.page ?? 1) - 1) * (query.limit ?? 20)).take(query.limit ?? 20);
-		const parties = await qb.getMany();
+	}): Promise<PartyListItemDto[]> {
+		const { gameId, isCompleted, isPrivate, page = 1, limit = 20 } = query;
+		const where: FindOptionsWhere<Party> = {};
 
-		// N+1 문제를 해결하기 위해 리더들의 게임 프로필을 한 번에 조회합니다.
+		if (gameId) where.gameId = gameId;
+		if (isCompleted !== undefined) where.isCompleted = isCompleted;
+		if (isPrivate !== undefined) where.isPrivate = isPrivate;
+
+		const parties = await this.partyRepository.find({
+			where,
+			relations: ['game', 'members', 'members.user'],
+			order: { createdAt: 'DESC' },
+			skip: (page - 1) * limit,
+			take: limit,
+		});
+
 		const leaderInfos = parties
 			.map((party) => {
 				const leader = party.members.find((m) => m.isLeader);
@@ -351,7 +249,6 @@ export class PartiesService {
 		const userGameProfilesMap =
 			await this.userGameProfilesService.getGameProfilesForUsers(leaderInfos);
 
-		// 각 파티별 리더, 멤버 수, 게임 배너, 리더의 게임네임 포함 변환
 		return parties.map((party) => {
 			const leader = party.members.find((m) => m.isLeader);
 			const leaderGameUsername =
@@ -359,7 +256,7 @@ export class PartiesService {
 					? userGameProfilesMap.get(`${leader.userId}-${party.gameId}`) || ''
 					: '';
 
-			const dto: import('../dto/response.dto').PartyListItemDto = {
+			return {
 				id: party.id,
 				title: party.title,
 				gameId: party.gameId,
@@ -382,13 +279,9 @@ export class PartiesService {
 						: null,
 				currentMemberCount: party.members.length,
 			};
-			return dto;
 		});
 	}
 
-	/**
-	 * 파티 완료 처리
-	 */
 	async completeParty(partyId: number, userId: number): Promise<void> {
 		const party = await this.partyRepository.findOne({ where: { id: partyId } });
 		if (!party) throw new AppException(ErrorCode.PARTY_NOT_FOUND);

--- a/src/parties/services/parties.service.ts
+++ b/src/parties/services/parties.service.ts
@@ -42,19 +42,20 @@ export class PartiesService {
 			const creator = await queryRunner.manager.findOneBy(User, { id: creatorId });
 			if (!creator) throw new AppException(ErrorCode.USER_NOT_FOUND);
 
-			let userGameProfile;
+			let userGameProfile: { id: number }; // 타입을 명확히 지정
 			if (dto.profileId) {
-				userGameProfile = await this.userGameProfilesService.getUserGameProfileById(
+				const profile = await this.userGameProfilesService.getUserGameProfileById(
 					dto.profileId,
 					creatorId,
 					dto.gameId,
 				);
-				if (!userGameProfile) {
+				if (!profile) {
 					throw new AppException(
 						ErrorCode.USER_GAME_PROFILE_NOT_FOUND,
 						'선택한 게임 프로필이 존재하지 않습니다.',
 					);
 				}
+				userGameProfile = profile;
 			} else if (dto.gameUsername) {
 				userGameProfile = await this.userGameProfilesService.findOrCreateUserGameProfile(
 					creatorId,
@@ -92,6 +93,7 @@ export class PartiesService {
 				partyId: newParty.id,
 				userId: creatorId,
 				isLeader: true,
+				userGameProfileId: userGameProfile.id, // 생성자의 게임 프로필 ID 저장
 			});
 			await queryRunner.manager.save(partyMember);
 
@@ -114,7 +116,7 @@ export class PartiesService {
 			// 리더의 게임 프로필을 명확히 조회하여 맵에 포함
 			const leaderUserId = creatorId;
 			const leaderGameId = dto.gameId;
-			const leaderProfile = userGameProfile as { gameUsername: string };
+			const leaderProfile = userGameProfile as { gameUsername: string; id: number }; // 타입 단언 추가
 			const userGameProfilesMap = new Map<string, string>();
 			if (leaderProfile && leaderProfile.gameUsername) {
 				userGameProfilesMap.set(

--- a/src/parties/services/parties.service.ts
+++ b/src/parties/services/parties.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { AppException } from '../../common/exceptions/app.exception';
 import { ErrorCode } from '../../common/constants/error-codes';
 import { InjectRepository } from '@nestjs/typeorm';
-import { DataSource, FindOptionsWhere, Repository } from 'typeorm';
+import { DataSource, FindOptionsWhere, In, Repository } from 'typeorm';
 import { Party } from '../entities/party.entity';
 import { Game } from '../../games/entities/game.entity';
 import { User } from '../../users/entities/user.entity';
@@ -19,6 +19,8 @@ export class PartiesService {
 	constructor(
 		@InjectRepository(Party)
 		private readonly partyRepository: Repository<Party>,
+		@InjectRepository(PartyMember)
+		private readonly partyMemberRepository: Repository<PartyMember>,
 		private readonly userGameProfilesService: UserGameProfilesService,
 		private readonly dataSource: DataSource,
 	) {}
@@ -237,6 +239,67 @@ export class PartiesService {
 			order: { createdAt: 'DESC' },
 			skip: (page - 1) * limit,
 			take: limit,
+		});
+
+		const leaderInfos = parties
+			.map((party) => {
+				const leader = party.members.find((m) => m.isLeader);
+				return leader ? { userId: leader.userId, gameId: party.gameId } : null;
+			})
+			.filter((info): info is { userId: number; gameId: number } => info !== null);
+
+		const userGameProfilesMap =
+			await this.userGameProfilesService.getGameProfilesForUsers(leaderInfos);
+
+		return parties.map((party) => {
+			const leader = party.members.find((m) => m.isLeader);
+			const leaderGameUsername =
+				leader && leader.user
+					? userGameProfilesMap.get(`${leader.userId}-${party.gameId}`) || ''
+					: '';
+
+			return {
+				id: party.id,
+				title: party.title,
+				gameId: party.gameId,
+				gameBannerUrl: party.game?.bannerUrl || '',
+				creatorId: party.creatorId,
+				purposeTag: party.purposeTag,
+				maxParticipants: party.maxParticipants,
+				description: party.description,
+				isPrivate: party.isPrivate,
+				isCompleted: party.isCompleted,
+				createdAt: party.createdAt,
+				updatedAt: party.updatedAt,
+				leader:
+					leader && leader.user
+						? {
+								userId: leader.user.id,
+								username: leader.user.username,
+								gameUsername: leaderGameUsername,
+							}
+						: null,
+				currentMemberCount: party.members.length,
+			};
+		});
+	}
+
+	async findUserParties(userId: number): Promise<PartyListItemDto[]> {
+		const userPartyMemberships = await this.partyMemberRepository.find({
+			where: { userId },
+			select: ['partyId'],
+		});
+
+		if (userPartyMemberships.length === 0) {
+			return [];
+		}
+
+		const partyIds = userPartyMemberships.map((m) => m.partyId);
+
+		const parties = await this.partyRepository.find({
+			where: { id: In(partyIds) },
+			relations: ['game', 'members', 'members.user'],
+			order: { createdAt: 'DESC' },
 		});
 
 		const leaderInfos = parties

--- a/src/parties/services/party-members.service.ts
+++ b/src/parties/services/party-members.service.ts
@@ -210,7 +210,7 @@ export class PartyMembersService {
 				username: member.user?.username || '',
 				isLeader: member.isLeader,
 				joinedAt: member.joinedAt?.toISOString(),
-				userGameProfile: { gameUsername },
+				gameUsername: gameUsername,
 			};
 		});
 

--- a/src/parties/services/party-members.service.ts
+++ b/src/parties/services/party-members.service.ts
@@ -6,10 +6,10 @@ import { Party } from '../entities/party.entity';
 import { User } from '../../users/entities/user.entity';
 import { AppException } from '../../common/exceptions/app.exception';
 import { ErrorCode } from '../../common/constants/error-codes';
-import { Game } from '../../games/entities/game.entity';
 import { MemberListResponseDto, PartyMemberDetailDto } from '../dto/response.dto';
 import { UserGameProfilesService } from '../../user-game-profiles/services/user-game-profiles.service';
 import { JoinPartyDto } from '../dto/join-party.dto';
+import { UserGameProfile } from 'src/user-game-profiles/entities/user-game-profile.entity';
 
 @Injectable()
 export class PartyMembersService {
@@ -18,8 +18,6 @@ export class PartyMembersService {
 		private readonly partyMemberRepository: Repository<PartyMember>,
 		@InjectRepository(Party)
 		private readonly partyRepository: Repository<Party>,
-		@InjectRepository(User)
-		private readonly userRepository: Repository<User>,
 		private readonly userGameProfilesService: UserGameProfilesService,
 		private readonly dataSource: DataSource,
 	) {}
@@ -29,190 +27,113 @@ export class PartyMembersService {
 		userId: number,
 		dto: JoinPartyDto,
 	): Promise<{ username: string }> {
-		const queryRunner = this.dataSource.createQueryRunner();
-		await queryRunner.connect();
-		await queryRunner.startTransaction();
-
-		try {
-			// FOR UPDATE로 파티 행에 배타적 잠금 설정 (동시성 제어)
-			const party = await queryRunner.manager
+		return this.dataSource.transaction(async (manager) => {
+			const party = await manager
 				.createQueryBuilder(Party, 'party')
 				.where('party.id = :partyId', { partyId })
-				.setLock('pessimistic_write') // FOR UPDATE
+				.setLock('pessimistic_write')
 				.getOne();
 
 			if (!party) throw new AppException(ErrorCode.PARTY_NOT_FOUND);
 
-			// 비공개 파티는 접근 코드 검증
-			if (party.isPrivate) {
-				if (!dto.accessCode || party.accessCode !== dto.accessCode) {
-					throw new AppException(ErrorCode.PARTY_INVALID_ACCESS_CODE);
-				}
+			if (party.isPrivate && (!dto.accessCode || party.accessCode !== dto.accessCode)) {
+				throw new AppException(ErrorCode.PARTY_INVALID_ACCESS_CODE);
 			}
 
-			// 이미 참가한 사용자인지 확인 (중복 참가 방지)
-			const exists = await queryRunner.manager.findOne(PartyMember, {
+			const existingMember = await manager.findOne(PartyMember, {
 				where: { partyId, userId },
 			});
-			if (exists) throw new AppException(ErrorCode.PARTY_ALREADY_JOINED);
+			if (existingMember) throw new AppException(ErrorCode.PARTY_ALREADY_JOINED);
 
-			// 현재 멤버 수 체크 (FOR UPDATE로 잠긴 상태에서 정확한 count)
-			const currentCount = await queryRunner.manager.count(PartyMember, {
-				where: { partyId },
-			});
+			const currentCount = await manager.count(PartyMember, { where: { partyId } });
 			if (currentCount >= party.maxParticipants) {
 				throw new AppException(ErrorCode.PARTY_MAX_PARTICIPANTS);
 			}
 
-			const user = await queryRunner.manager.findOne(User, { where: { id: userId } });
+			const user = await manager.findOne(User, { where: { id: userId } });
 			if (!user) throw new AppException(ErrorCode.USER_NOT_FOUND);
 
-			const game = await queryRunner.manager.findOne(Game, { where: { id: party.gameId } });
-			if (!game) throw new AppException(ErrorCode.GAME_NOT_FOUND);
-
-			// UserGameProfile 조회/생성
-			let userGameProfile: { id: number } | null = null;
+			let userGameProfile: UserGameProfile | null;
 			if (dto.profileId) {
-				const profile = await this.userGameProfilesService.getUserGameProfileById(
+				userGameProfile = await this.userGameProfilesService.getUserGameProfileById(
 					dto.profileId,
 					userId,
 					party.gameId,
 				);
-				if (!profile) {
+				if (!userGameProfile) {
 					throw new AppException(
 						ErrorCode.USER_GAME_PROFILE_NOT_FOUND,
 						'선택한 게임 프로필이 존재하지 않습니다.',
 					);
 				}
-				userGameProfile = { id: profile.id };
 			} else if (dto.gameUsername) {
-				const profile = await this.userGameProfilesService.findOrCreateUserGameProfile(
+				userGameProfile = await this.userGameProfilesService.findOrCreateUserGameProfile(
 					userId,
 					party.gameId,
 					dto.gameUsername,
 				);
-				userGameProfile = { id: profile.id };
 			} else {
-				// DTO에서 이미 검증하지만, 서비스 계층에서도 방어적으로 확인
 				throw new AppException(
 					ErrorCode.VALIDATION_ERROR,
 					'게임 프로필 정보(profileId 또는 gameUsername)가 필요합니다.',
 				);
 			}
 
-			const newMember = this.partyMemberRepository.create({
+			const newMember = manager.create(PartyMember, {
 				partyId,
 				userId,
-				userGameProfileId: userGameProfile?.id,
+				userGameProfileId: userGameProfile.id,
 			});
-			await queryRunner.manager.save(newMember);
+			await manager.save(newMember);
 
-			await queryRunner.commitTransaction();
 			return { username: user.username };
-		} catch (error: unknown) {
-			await queryRunner.rollbackTransaction();
-			if (error instanceof AppException) throw error;
-			// DB 제약 조건 위반 (중복 참가) 처리
-			if (error instanceof Error && error.message.includes('Duplicate entry')) {
-				throw new AppException(ErrorCode.PARTY_ALREADY_JOINED);
-			}
-			throw new AppException(ErrorCode.INTERNAL_SERVER_ERROR);
-		} finally {
-			await queryRunner.release();
-		}
+		});
 	}
 
 	async leaveParty(partyId: number, userId: number): Promise<{ username: string }> {
-		const queryRunner = this.dataSource.createQueryRunner();
-		await queryRunner.connect();
-		await queryRunner.startTransaction();
-
-		try {
-			const member = await queryRunner.manager.findOne(PartyMember, {
+		return this.dataSource.transaction(async (manager) => {
+			const member = await manager.findOne(PartyMember, {
 				where: { partyId, userId },
 				relations: ['user'],
 			});
 			if (!member) throw new AppException(ErrorCode.PARTY_MEMBER_NOT_FOUND);
+			if (member.isLeader) throw new AppException(ErrorCode.PARTY_LEADER_CANNOT_LEAVE);
 
-			// 파티장은 탈퇴할 수 없음
-			if (member.isLeader) {
-				throw new AppException(ErrorCode.PARTY_LEADER_CANNOT_LEAVE);
-			}
-
-			// userId가 undefined/null이면 DB row가 손상된 상태이므로 즉시 예외
-			if (typeof member.userId !== 'number' || !member.userId) {
-				throw new AppException(
-					ErrorCode.INTERNAL_SERVER_ERROR,
-					'PartyMember row의 userId가 유효하지 않습니다.',
-				);
-			}
-
-			let username = '';
-			if (member.user && member.user.username) {
-				username = member.user.username;
-			} else {
-				// user relation이 undefined인 경우 직접 조회
-				const user = await queryRunner.manager.findOne(User, {
-					where: { id: member.userId },
-				});
-				if (!user) {
-					throw new AppException(
-						ErrorCode.USER_NOT_FOUND,
-						'PartyMember의 userId에 해당하는 사용자가 존재하지 않습니다.',
-					);
-				}
-				username = user.username;
-			}
-
-			await queryRunner.manager.remove(member);
-			await queryRunner.commitTransaction();
-			return { username };
-		} catch (error: unknown) {
-			await queryRunner.rollbackTransaction();
-			if (error instanceof AppException) throw error;
-			throw new AppException(ErrorCode.INTERNAL_SERVER_ERROR);
-		} finally {
-			await queryRunner.release();
-		}
+			await manager.remove(member);
+			return { username: member.user.username };
+		});
 	}
 
 	async getPartyMembers(partyId: number): Promise<MemberListResponseDto> {
+		const party = await this.partyRepository.findOne({ where: { id: partyId } });
+		if (!party) throw new AppException(ErrorCode.PARTY_NOT_FOUND);
+
 		const members = await this.partyMemberRepository.find({
 			where: { partyId },
 			relations: ['user'],
 		});
 
-		const party = await this.partyRepository.findOne({ where: { id: partyId } });
-		if (!party) throw new AppException(ErrorCode.PARTY_NOT_FOUND);
-
-		// userGameProfileId가 있는 멤버들의 프로필을 한 번에 조회
 		const profileIdList = members
 			.map((m) => m.userGameProfileId)
 			.filter((id): id is number => !!id);
-		let profileMap: Map<number, string> = new Map();
+
+		const profileMap = new Map<number, string>();
 		if (profileIdList.length > 0) {
 			const profiles = await this.userGameProfilesService.getProfilesByIds(profileIdList);
-			profileMap = new Map(profiles.map((p) => [p.id, p.gameUsername]));
+			profiles.forEach((p) => profileMap.set(p.id, p.gameUsername));
 		}
 
-		const memberDtos: PartyMemberDetailDto[] = members.map((member) => {
-			let gameUsername = '';
-			if (member.userGameProfileId) {
-				gameUsername = profileMap.get(member.userGameProfileId) || '';
-			}
-			// fallback: userGameProfileId가 없거나, 매칭되는 프로필이 없는 경우
-			if (!gameUsername) {
-				gameUsername = '';
-			}
-			return {
-				id: member.id,
-				userId: member.userId,
-				username: member.user?.username || '',
-				isLeader: member.isLeader,
-				joinedAt: member.joinedAt?.toISOString(),
-				gameUsername: gameUsername,
-			};
-		});
+		const memberDtos: PartyMemberDetailDto[] = members.map((member) => ({
+			id: member.id,
+			userId: member.userId,
+			username: member.user?.username || '',
+			isLeader: member.isLeader,
+			joinedAt: member.joinedAt?.toISOString(),
+			gameUsername:
+				member.userGameProfileId && profileMap.has(member.userGameProfileId)
+					? profileMap.get(member.userGameProfileId)!
+					: '',
+		}));
 
 		return {
 			members: memberDtos,
@@ -224,110 +145,57 @@ export class PartyMembersService {
 	async kickMember(
 		partyId: number,
 		leaderId: number,
-		userId: number,
+		userIdToKick: number,
 	): Promise<{ username: string }> {
-		const queryRunner = this.dataSource.createQueryRunner();
-		await queryRunner.connect();
-		await queryRunner.startTransaction();
-
-		try {
-			const party = await queryRunner.manager.findOne(Party, { where: { id: partyId } });
-			if (!party) throw new AppException(ErrorCode.PARTY_NOT_FOUND);
-
-			// 자기 자신을 강퇴할 수 없음
-			if (leaderId === userId) {
+		return this.dataSource.transaction(async (manager) => {
+			if (leaderId === userIdToKick) {
 				throw new AppException(ErrorCode.PARTY_SELF_ACTION_NOT_ALLOWED);
 			}
 
-			const leader = await queryRunner.manager.findOne(PartyMember, {
+			const leader = await manager.findOne(PartyMember, {
 				where: { partyId, userId: leaderId },
 			});
 			if (!leader || !leader.isLeader) throw new AppException(ErrorCode.PARTY_NOT_LEADER);
 
-			const member = await queryRunner.manager.findOne(PartyMember, {
-				where: { partyId, userId },
+			const memberToKick = await manager.findOne(PartyMember, {
+				where: { partyId, userId: userIdToKick },
 				relations: ['user'],
 			});
-			if (!member) throw new AppException(ErrorCode.PARTY_MEMBER_NOT_FOUND);
+			if (!memberToKick) throw new AppException(ErrorCode.PARTY_MEMBER_NOT_FOUND);
 
-			let username = '';
-			if (member.user && member.user.username) {
-				username = member.user.username;
-			} else if (member.userId) {
-				// user relation이 undefined인 경우 직접 조회
-				const user = await queryRunner.manager.findOne(User, {
-					where: { id: member.userId },
-				});
-				// 방어 코드: user가 없을 경우에도 대비
-				username = user?.username || '';
-			}
-
-			await queryRunner.manager.remove(member);
-			await queryRunner.commitTransaction();
-
-			return { username };
-		} catch (error: unknown) {
-			await queryRunner.rollbackTransaction();
-			if (error instanceof AppException) throw error;
-			throw new AppException(ErrorCode.INTERNAL_SERVER_ERROR);
-		} finally {
-			await queryRunner.release();
-		}
+			await manager.remove(memberToKick);
+			return { username: memberToKick.user.username };
+		});
 	}
 
 	async changeLeader(
 		partyId: number,
-		leaderId: number,
+		currentLeaderId: number,
 		newLeaderId: number,
 	): Promise<{ username: string }> {
-		const queryRunner = this.dataSource.createQueryRunner();
-		await queryRunner.connect();
-		await queryRunner.startTransaction();
-
-		try {
-			const party = await queryRunner.manager.findOne(Party, { where: { id: partyId } });
-			if (!party) throw new AppException(ErrorCode.PARTY_NOT_FOUND);
-
-			// 자기 자신에게 권한을 이양할 수 없음
-			if (leaderId === newLeaderId) {
+		return this.dataSource.transaction(async (manager) => {
+			if (currentLeaderId === newLeaderId) {
 				throw new AppException(ErrorCode.PARTY_SELF_ACTION_NOT_ALLOWED);
 			}
 
-			const leader = await queryRunner.manager.findOne(PartyMember, {
-				where: { partyId, userId: leaderId },
+			const currentLeader = await manager.findOne(PartyMember, {
+				where: { partyId, userId: currentLeaderId },
 			});
-			if (!leader || !leader.isLeader) throw new AppException(ErrorCode.PARTY_NOT_LEADER);
+			if (!currentLeader || !currentLeader.isLeader) {
+				throw new AppException(ErrorCode.PARTY_NOT_LEADER);
+			}
 
-			const newLeader = await queryRunner.manager.findOne(PartyMember, {
+			const newLeader = await manager.findOne(PartyMember, {
 				where: { partyId, userId: newLeaderId },
 				relations: ['user'],
 			});
 			if (!newLeader) throw new AppException(ErrorCode.PARTY_MEMBER_NOT_FOUND);
 
-			leader.isLeader = false;
+			currentLeader.isLeader = false;
 			newLeader.isLeader = true;
-			await queryRunner.manager.save([leader, newLeader]);
+			await manager.save([currentLeader, newLeader]);
 
-			let username = '';
-			if (newLeader.user && newLeader.user.username) {
-				username = newLeader.user.username;
-			} else if (newLeader.userId) {
-				// user relation이 undefined인 경우 직접 조회
-				const user = await queryRunner.manager.findOne(User, {
-					where: { id: newLeader.userId },
-				});
-				username = user?.username || '';
-			}
-
-			await queryRunner.commitTransaction();
-
-			return { username };
-		} catch (error: unknown) {
-			await queryRunner.rollbackTransaction();
-			if (error instanceof AppException) throw error;
-			throw new AppException(ErrorCode.INTERNAL_SERVER_ERROR);
-		} finally {
-			await queryRunner.release();
-		}
+			return { username: newLeader.user.username };
+		});
 	}
 }

--- a/src/swagger-static.ts
+++ b/src/swagger-static.ts
@@ -14,6 +14,9 @@ async function bootstrap() {
 		.addTag('auth', '인증 관리 API')
 		.addTag('users', '사용자 관리 API')
 		.addTag('parties', '파티 관리 API')
+		.addTag('partyMembers', '파티 멤버 관리 API')
+		.addTag('games', '게임 관리 API')
+		.addTag('userGameProfiles', '사용자 게임 프로필 관리 API')
 		.addTag('likes', '좋아요 관리 API')
 		.addBearerAuth(
 			{


### PR DESCRIPTION
## 주요 변경 사항

### 1. 파티/파티원 API 기능 추가 및 개선
- **파티 생성 시**: UserGameProfiles 테이블에 해당 게임의 프로필이 없으면 자동 생성(비즈니스 로직 보강)
- **파티 수정 시**: 게임 프로필 변경/생성 로직 추가
- **파티 삭제, 완료 처리 등**: 주요 액션의 권한 및 예외 처리 강화
- **파티 목록, 내 파티 목록 조회**: 리더의 게임 프로필 정보 포함 등 응답 데이터 구조 개선

### 2. Swagger 문서 그룹 및 설명 일관성 개선
- `swagger-static.ts`에 `partyMembers`, `games`, `userGameProfiles` 태그 및 설명 추가
- 각 컨트롤러(`parties`, `party-members`, `games`, `user-game-profiles`)의 `@ApiTags`를 Swagger 태그와 정확히 일치하도록 소문자 카멜케이스로 통일
- Swagger 문서에서 그룹별 설명이 정상적으로 노출되도록 태그 대소문자 및 표기 일치 처리

### 3. 에러 응답 및 문서 일관성 강화
- `parties.controller.ts`, `party-members.controller.ts`의 Swagger 에러 응답 예시(@ApiBadRequestResponse, @ApiUnauthorizedResponse 등)를 실제 서비스 로직과 일치하도록 보강
- `common/constants/error-codes.ts`의 커스텀 에러코드와 서비스/컨트롤러/문서 간 불일치 부분을 통일
- 서비스 레이어의 에러 발생 로직과 Swagger 문서의 에러코드가 일치하도록 점검 및 수정

### 4. 기타
- 불필요한 타임존 관련 옵션/설정 제거

---

**요약:**  
파티/파티원 API의 실질적 기능 개선(게임 프로필 자동 생성, 권한/예외 처리 강화 등)과 함께, Swagger 문서 그룹화 및 에러 응답 일관성을 대폭 개선하였습니다.  
API 문서와 실제 동작이 최대한 일치하도록 보완하였으며, 신규 기능 및 구조 개선이 포함 되어 있습니다.

## Important
All developers on this project are Korean.
Therefore, please ensure all code reviews and comments are written in Korean so that they are easily understood by the team.